### PR TITLE
update change linewise behavior to more closely match vim 

### DIFF
--- a/src/vim.js
+++ b/src/vim.js
@@ -2186,6 +2186,7 @@ export function initVim(CodeMirror) {
             head = ranges[0].head;
         if (!vim.visualMode) {
           text = cm.getRange(anchor, head);
+          var leadingNonLineWhiteSpace = (/[^\S\r\n]*/).exec(text);
           var lastState = vim.lastEditInputState || {};
           if (lastState.motion == "moveByWords" && !isWhiteSpaceString(text)) {
             // Exclude trailing whitespace if the range is not all whitespace.
@@ -2207,6 +2208,9 @@ export function initVim(CodeMirror) {
             if (!wasLastLine) {
               cm.setCursor(prevLineEnd);
               CodeMirror.commands.newlineAndIndent(cm);
+            }
+            if(leadingNonLineWhiteSpace[0]) {
+              cm.replaceRange(leadingNonLineWhiteSpace[0], new Pos(anchor.line, 0), new Pos(anchor.line, Number.MAX_VALUE));
             }
             // make sure cursor ends up at the end of the line.
             anchor.ch = Number.MAX_VALUE;


### PR DESCRIPTION
When operating linewise with "change" commands, cc, S, cip etc, whitespace at the beginning of the line is preserved in vim. This implements that.