### PR TITLE
Fix documentation Example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ let view = new EditorView({
 The same api that could be used in previous version of codemirror https://codemirror.net/doc/manual.html#vimapi, can be used with this plugin too, just replace the old editor instance with `view.cm` in your code
 
 ```js
-import {Vim, getCm} from "@replit/codemirror-vim"
+import {Vim, getCM} from "@replit/codemirror-vim"
 
-let cm = getCm(view)
+let cm = getCM(view)
 // use cm to access the old cm5 api
 Vim.exitInsertMode(cm)
 Vim.handleKey(cm, "<Esc>")


### PR DESCRIPTION
Fix example code on README

Changes

```js
import {Vim, getCm} from "@replit/codemirror-vim"

let cm = getCm(view)
```

to 
```js
import {Vim, getCM} from "@replit/codemirror-vim"

let cm = getCM(view)
```

Fix typo from `getCm` to `getCM` on `README.md`