### PR TITLE
feat: implement is and as (sentence)

### DIFF
--- a/src/vim.js
+++ b/src/vim.js
@@ -2133,6 +2133,25 @@ export function initVim(CodeMirror) {
           }
         } else if (character === 't') {
           tmp = expandTagUnderCursor(cm, head, inclusive);
+        } else if (character === 's') {
+          var curLine = cm.getLine(head.line);
+          var start;
+          if (
+              head.ch === 0
+              || (isWhiteSpaceString(curLine[head.ch - 1]) && isEndOfSentenceSymbol(curLine[head.ch - 2]))
+              || (isEndOfSentenceSymbol(curLine[head.ch - 1]))
+          ) {
+            start = head;
+          } else {
+            start = findSentence(cm, head, motionArgs.repeat, -1);
+          }
+          var end;
+          if (isEndOfSentenceSymbol(curLine[head.ch])) {
+            end = {line: head.line, ch: head.ch + 1};
+          } else {
+            end = findSentence(cm, head, motionArgs.repeat, 1);
+          }
+          tmp = {start: start, end: end};
         } else {
           // No text object defined for this, don't move.
           return null;


### PR DESCRIPTION
I added <kbd>s</kbd> to `textObjectManipulation`, so that movements like <kbd>vis</kbd>, <kbd>vas</kbd>, <kbd>dis</kbd> and <kbd>das</kbd> are possible. I use the function that is for moving to the sentence before/after <kbd>(</kbd>/<kbd>)</kbd>, which is not explicitly made for <kbd>s</kbd>. This is why I added some checks.

They are not perfect, however. If the cursor is not at the beginning of the sentence, but in whitespace before it (not the one immediately before it combined with a sentence end), then it will also select the sentence before it, as can be seen in the video.

It also supports repeat characters, although possibly not correctly at all times.

`is` and `as` are currently doing the same thing. To handle all of it correctly, it would need to be newly implemented instead of reusing another function.

I think this is good enough though, considering that <kbd>s</kbd> is mostly used for writing texts and having it in this vim emulation, even if it doesn't work perfectly, is better than not having it at all.


https://user-images.githubusercontent.com/83140328/174480654-ecc8b2a6-29a6-4794-8877-957e878404c4.mp4


