### PR TITLE
Merge upstream fixes to Vim keybindings

### DIFF
--- a/src/vim.js
+++ b/src/vim.js
@@ -214,8 +214,8 @@ export function initVim(CodeMirror) {
     { keys: 'z.', type: 'action', action: 'scrollToCursor', actionArgs: { position: 'center' }, motion: 'moveToFirstNonWhiteSpaceCharacter' },
     { keys: 'zt', type: 'action', action: 'scrollToCursor', actionArgs: { position: 'top' }},
     { keys: 'z<CR>', type: 'action', action: 'scrollToCursor', actionArgs: { position: 'top' }, motion: 'moveToFirstNonWhiteSpaceCharacter' },
-    { keys: 'z-', type: 'action', action: 'scrollToCursor', actionArgs: { position: 'bottom' }},
-    { keys: 'zb', type: 'action', action: 'scrollToCursor', actionArgs: { position: 'bottom' }, motion: 'moveToFirstNonWhiteSpaceCharacter' },
+    { keys: 'zb', type: 'action', action: 'scrollToCursor', actionArgs: { position: 'bottom' }},
+    { keys: 'z-', type: 'action', action: 'scrollToCursor', actionArgs: { position: 'bottom' }, motion: 'moveToFirstNonWhiteSpaceCharacter' },
     { keys: '.', type: 'action', action: 'repeatLastEdit' },
     { keys: '<C-a>', type: 'action', action: 'incrementNumberToken', isEdit: true, actionArgs: {increase: true, backtrack: false}},
     { keys: '<C-x>', type: 'action', action: 'incrementNumberToken', isEdit: true, actionArgs: {increase: false, backtrack: false}},
@@ -2403,11 +2403,14 @@ export function initVim(CodeMirror) {
         var charCoords = cm.charCoords(new Pos(lineNum, 0), 'local');
         var height = cm.getScrollInfo().clientHeight;
         var y = charCoords.top;
-        var lineHeight = charCoords.bottom - y;
         switch (actionArgs.position) {
-          case 'center': y = y - (height / 2) + lineHeight;
+          case 'center': y = charCoords.bottom - height / 2;
             break;
-          case 'bottom': y = y - height + lineHeight;
+          case 'bottom':
+            var lineLastCharPos = new Pos(lineNum, cm.getLine(lineNum).length - 1);
+            var lineLastCharCoords = cm.charCoords(lineLastCharPos, 'local');
+            var lineHeight = lineLastCharCoords.bottom - y;
+            y = y - height + lineHeight
             break;
         }
         cm.scrollTo(null, y);


### PR DESCRIPTION
This PR merges two recent fixes made to `vim.js` in CodeMirror 5.

We have further fixes for CodeMirror 6 Vim keybindings that we would like to contribute. In [#5](https://github.com/replit/codemirror-vim/pull/5#issuecomment-1009425871), it was mentioned that the master version of `vim.js` comes from the CodeMirror 5 repo; however, the version in this repo has [deviated somewhat from that](https://github.com/timdown/codemirror-vim/commit/b47cd6a859e081d85e85726690a3e5e93ab705db), so I'm unsure what the intention regarding keeping these files in sync is, and therefore how to proceed. It would improve things for CodeMirror 6 if we could use CodeMirror 6 API calls rather than go through the adapter (for example, we could use `scrollIntoView()` in `scrollToCursor()` rather than doing bespoke calculations) but I'm happy to continue to work with the adapter instead.