### PR TITLE
Highlight search results in newly rendered content when viewport changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,20 +78,21 @@ const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
   }
 
   update(update: ViewUpdate) {
+    if ((update.viewportChanged || update.docChanged) && this.query) {
+      this.highlight(this.query)
+    }
     if (update.docChanged) {
       this.cm.onChange(update)
-      if (this.query)
-        this.highlight(this.query)
-    } 
+    }
     if (update.selectionSet) {
       this.cm.onSelectionChange()
-    } 
+    }
     if (update.viewportChanged) {
       // scroll
     }
     if (this.cm.curOp && !this.cm.curOp.isVimOp) {
       this.cm.onBeforeEndOperation();
-    } 
+    }
     if (update.transactions) {
       for (let tr of update.transactions)
       for (let effect of tr.effects) {


### PR DESCRIPTION
Currently, search results are not highlighted when the viewport changes. Reproduction steps:

1. Open a CM6 editor with a word repeated many times
2. Position the cursor on an early instance of the repeated word
3. Press * and keep pressing it until matches are no longer highlighted

![search2](https://user-images.githubusercontent.com/158919/176946448-3e95dd7a-e61c-4b7f-b989-c080bec9bcd2.gif)

This PR fixes it.
