### PR TITLE
Handle keydown events according to CM6 API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,11 +31,10 @@ type EditorViewExtended = EditorView&{cm:CodeMirror}
 
 const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
   private dom: HTMLElement;
-  private keydownHandler;
   public view: EditorViewExtended;
   public cm: CodeMirror;
   public status = ""
-  blockCursor: BlockCursorPlugin
+  blockCursor: BlockCursorPlugin 
   constructor(view: EditorView) {
     this.view = view as EditorViewExtended
     const cm = this.cm = new CodeMirror(view);
@@ -52,7 +51,6 @@ const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
       this.blockCursor.scheduleRedraw();
       this.updateStatus()
     });
-
     this.cm.on('vim-mode-change', (e: any) => {
       cm.state.vim.mode = e.mode;
       if (e.subMode) {
@@ -63,6 +61,7 @@ const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
       this.updateClass()
       this.updateStatus()
     });
+    
 
     this.cm.on("dialog", () => {
       if (this.cm.state.statusbar) {
@@ -76,56 +75,10 @@ const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
 
     this.dom = document.createElement("span");
     this.dom.style.cssText = "position: absolute; right: 10px; top: 1px";
-
-    // Add a capturing event handler to ensure CodeMirror hasn't had a chance to prevent the default behaviour
-    this.keydownHandler = (e: KeyboardEvent) => {
-      if (e.target === view.contentDOM) {
-        this.handleKeydownEvent(e)
-      }
-    }
-
-    // The event handler needs to be attached to the document in order to catch it in the capturing phase
-    view.contentDOM.ownerDocument.addEventListener('keydown', this.keydownHandler, { capture: true })
-  }
-
-  handleKeydownEvent(e: KeyboardEvent) {
-    const key = CodeMirror.vimKey(e)
-    const cm = this.cm
-    if (!key) return
-
-    // clear search highlight
-    let vim = cm.state.vim
-    if (key == "<Esc>"
-        && !vim.insertMode && !vim.visualMode
-        && this.query/* && !cm.inMultiSelectMode*/
-    ) {
-      cm.removeOverlay(null);
-    }
-
-    cm.state.vim.status = (cm.state.vim.status|| "") + key
-    let result = Vim.multiSelectHandleKey(cm, key, "user");
-
-    // insert mode
-    if (!result && cm.state.vim.insertMode && cm.state.overwrite) {
-      if (e.key && e.key.length == 1 && !/\n/.test(e.key)) {
-        result = true;
-        cm.overWriteSelection(e.key)
-      } else if (e.key == "Backspace") {
-        result = true;
-        CodeMirror.commands.cursorCharLeft(cm)
-      }
-    }
-    if (result) {
-      e.preventDefault()
-      e.stopPropagation()
-      this.blockCursor.scheduleRedraw();
-    }
-
-    this.updateStatus()
   }
 
   update(update: ViewUpdate) {
-    if (this.query && (update.viewportChanged || update.docChanged)) {
+    if ((update.viewportChanged || update.docChanged) && this.query) {
       this.highlight(this.query)
     }
     if (update.docChanged) {
@@ -161,7 +114,7 @@ const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
     const state = this.cm.state;
     if (!state.vim || (state.vim.insertMode && !state.overwrite))
       this.view.scrollDOM.classList.remove("cm-vimMode")
-    else
+    else 
       this.view.scrollDOM.classList.add("cm-vimMode")
   }
   updateStatus() {
@@ -187,13 +140,11 @@ const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
     this.updateClass()
     this.blockCursor.destroy();
     delete (this.view as any).cm;
-    this.view.contentDOM.ownerDocument.removeEventListener('keydown', this.keydownHandler, { capture: true })
-    this.keydownHandler = () => {}
   }
 
   highlight(query: any) {
     this.query = query;
-    if (!query)
+    if (!query) 
       return this.decorations = Decoration.none
     let {view} = this
     let builder = new RangeSetBuilder<Decoration>()
@@ -210,6 +161,46 @@ const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
   decorations = Decoration.none
 
 }, {
+  eventHandlers: {
+    keydown: function(e: KeyboardEvent, view: EditorView) {
+      const key = CodeMirror.vimKey(e)
+      const cm = this.cm
+      if (!key) return
+      
+      // clear search highlight
+      let vim = cm.state.vim
+      if (key == "<Esc>"
+       && !vim.insertMode && !vim.visualMode 
+       && this.query/* && !cm.inMultiSelectMode*/
+      ) {
+        cm.removeOverlay(null);
+      }
+
+      cm.state.vim.status = (cm.state.vim.status|| "") + key
+      let result = Vim.multiSelectHandleKey(cm, key, "user");
+
+      // insert mode
+      if (!result && cm.state.vim.insertMode && cm.state.overwrite) {
+        if (e.key && e.key.length == 1 && !/\n/.test(e.key)) {
+          result = true;
+          cm.overWriteSelection(e.key)
+        } else if (e.key == "Backspace") {
+          result = true;
+          CodeMirror.commands.cursorCharLeft(cm)
+        }
+      }
+      if (result) {
+        e.preventDefault()
+        e.stopPropagation()
+        this.blockCursor.scheduleRedraw();
+      } 
+
+      this.updateStatus()
+
+      return !!result;
+    }
+  },
+  
   decorations: v => v.decorations
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,25 @@
-import {initVim} from "./vim"
-import { CodeMirror } from "./cm_adapter"
-import { BlockCursorPlugin, hideNativeSelection } from "./block-cursor"
-import { Extension, StateField, StateEffect, RangeSetBuilder } from "@codemirror/state"
-import { ViewPlugin, PluginValue, ViewUpdate, Decoration, EditorView, showPanel, Panel } from "@codemirror/view"
-import { setSearchQuery } from "@codemirror/search"
+import { initVim } from "./vim";
+import { CodeMirror } from "./cm_adapter";
+import { BlockCursorPlugin, hideNativeSelection } from "./block-cursor";
+import {
+  Extension,
+  StateField,
+  StateEffect,
+  RangeSetBuilder,
+  Prec,
+} from "@codemirror/state";
+import {
+  ViewPlugin,
+  PluginValue,
+  ViewUpdate,
+  Decoration,
+  EditorView,
+  showPanel,
+  Panel,
+} from "@codemirror/view";
+import { setSearchQuery } from "@codemirror/search";
 
-const Vim = initVim(CodeMirror)
+const Vim = initVim(CodeMirror);
 
 const HighlightMargin = 250;
 
@@ -26,229 +40,241 @@ const vimStyle = EditorView.baseTheme({
 
   "&light .cm-searchMatch": { backgroundColor: "#ffff0054" },
   "&dark .cm-searchMatch": { backgroundColor: "#00ffff8a" },
-})
-type EditorViewExtended = EditorView&{cm:CodeMirror}
+});
+type EditorViewExtended = EditorView & { cm: CodeMirror };
 
-const vimPlugin = ViewPlugin.fromClass(class implements PluginValue {
-  private dom: HTMLElement;
-  public view: EditorViewExtended;
-  public cm: CodeMirror;
-  public status = ""
-  blockCursor: BlockCursorPlugin 
-  constructor(view: EditorView) {
-    this.view = view as EditorViewExtended
-    const cm = this.cm = new CodeMirror(view);
-    Vim.enterVimMode(this.cm);
+const vimPlugin = ViewPlugin.fromClass(
+  class implements PluginValue {
+    private dom: HTMLElement;
+    public view: EditorViewExtended;
+    public cm: CodeMirror;
+    public status = "";
+    blockCursor: BlockCursorPlugin;
+    constructor(view: EditorView) {
+      this.view = view as EditorViewExtended;
+      const cm = (this.cm = new CodeMirror(view));
+      Vim.enterVimMode(this.cm);
 
-    this.view.cm = this.cm
-    this.cm.state.vimPlugin = this
+      this.view.cm = this.cm;
+      this.cm.state.vimPlugin = this;
 
-    this.blockCursor = new BlockCursorPlugin(view, cm)
-    this.updateClass()
+      this.blockCursor = new BlockCursorPlugin(view, cm);
+      this.updateClass();
 
-    this.cm.on('vim-command-done', () => {
-      if (cm.state.vim) cm.state.vim.status = "";
-      this.blockCursor.scheduleRedraw();
-      this.updateStatus()
-    });
-    this.cm.on('vim-mode-change', (e: any) => {
-      cm.state.vim.mode = e.mode;
-      if (e.subMode) {
-        cm.state.vim.mode += " block"
+      this.cm.on("vim-command-done", () => {
+        if (cm.state.vim) cm.state.vim.status = "";
+        this.blockCursor.scheduleRedraw();
+        this.updateStatus();
+      });
+      this.cm.on("vim-mode-change", (e: any) => {
+        cm.state.vim.mode = e.mode;
+        if (e.subMode) {
+          cm.state.vim.mode += " block";
+        }
+        cm.state.vim.status = "";
+        this.blockCursor.scheduleRedraw();
+        this.updateClass();
+        this.updateStatus();
+      });
+
+      this.cm.on("dialog", () => {
+        if (this.cm.state.statusbar) {
+          this.updateStatus();
+        } else {
+          view.dispatch({
+            effects: showVimPanel.of(!!this.cm.state.dialog),
+          });
+        }
+      });
+
+      this.dom = document.createElement("span");
+      this.dom.style.cssText = "position: absolute; right: 10px; top: 1px";
+    }
+
+    update(update: ViewUpdate) {
+      if ((update.viewportChanged || update.docChanged) && this.query) {
+        this.highlight(this.query);
       }
-      cm.state.vim.status = "";
-      this.blockCursor.scheduleRedraw();
-      this.updateClass()
-      this.updateStatus()
-    });
-    
+      if (update.docChanged) {
+        this.cm.onChange(update);
+      }
+      if (update.selectionSet) {
+        this.cm.onSelectionChange();
+      }
+      if (update.viewportChanged) {
+        // scroll
+      }
+      if (this.cm.curOp && !this.cm.curOp.isVimOp) {
+        this.cm.onBeforeEndOperation();
+      }
+      if (update.transactions) {
+        for (let tr of update.transactions)
+          for (let effect of tr.effects) {
+            if (effect.is(setSearchQuery)) {
+              let forVim = (effect.value as any)?.forVim;
+              if (!forVim) {
+                this.highlight(null);
+              } else {
+                let query = (effect.value as any).create();
+                this.highlight(query);
+              }
+            }
+          }
+      }
 
-    this.cm.on("dialog", () => {
-      if (this.cm.state.statusbar) {
-        this.updateStatus()
+      this.blockCursor.update(update);
+    }
+    updateClass() {
+      const state = this.cm.state;
+      if (!state.vim || (state.vim.insertMode && !state.overwrite))
+        this.view.scrollDOM.classList.remove("cm-vimMode");
+      else this.view.scrollDOM.classList.add("cm-vimMode");
+    }
+    updateStatus() {
+      let dom = this.cm.state.statusbar;
+      if (!dom) return;
+      let dialog = this.cm.state.dialog;
+      let vim = this.cm.state.vim;
+      if (dialog) {
+        if (dialog.parentElement != dom) {
+          dom.textContent = "";
+          dom.appendChild(dialog);
+        }
       } else {
-        view.dispatch({
-          effects: showVimPanel.of(!!this.cm.state.dialog)
-        })
+        dom.textContent = `--${(vim.mode || "normal").toUpperCase()}--`;
       }
-    });
 
-    this.dom = document.createElement("span");
-    this.dom.style.cssText = "position: absolute; right: 10px; top: 1px";
-  }
+      this.dom.textContent = vim.status;
+      dom.appendChild(this.dom);
+    }
 
-  update(update: ViewUpdate) {
-    if ((update.viewportChanged || update.docChanged) && this.query) {
-      this.highlight(this.query)
+    destroy() {
+      this.cm.state.vim = null;
+      this.updateClass();
+      this.blockCursor.destroy();
+      delete (this.view as any).cm;
     }
-    if (update.docChanged) {
-      this.cm.onChange(update)
+
+    highlight(query: any) {
+      this.query = query;
+      if (!query) return (this.decorations = Decoration.none);
+      let { view } = this;
+      let builder = new RangeSetBuilder<Decoration>();
+      for (
+        let i = 0, ranges = view.visibleRanges, l = ranges.length;
+        i < l;
+        i++
+      ) {
+        let { from, to } = ranges[i];
+        while (i < l - 1 && to > ranges[i + 1].from - 2 * HighlightMargin)
+          to = ranges[++i].to;
+        query.highlight(
+          view.state.doc,
+          from,
+          to,
+          (from: number, to: number) => {
+            builder.add(from, to, matchMark);
+          }
+        );
+      }
+      return (this.decorations = builder.finish());
     }
-    if (update.selectionSet) {
-      this.cm.onSelectionChange()
-    }
-    if (update.viewportChanged) {
-      // scroll
-    }
-    if (this.cm.curOp && !this.cm.curOp.isVimOp) {
-      this.cm.onBeforeEndOperation();
-    }
-    if (update.transactions) {
-      for (let tr of update.transactions)
-      for (let effect of tr.effects) {
-        if (effect.is(setSearchQuery)) {
-          let forVim = (effect.value as any)?.forVim
-          if (!forVim) {
-            this.highlight(null)
-          } else {
-            let query = (effect.value as any).create()
-            this.highlight(query)
+    query = null;
+    decorations = Decoration.none;
+  },
+  {
+    eventHandlers: {
+      keydown: function (e: KeyboardEvent, view: EditorView) {
+        const key = CodeMirror.vimKey(e);
+        const cm = this.cm;
+        if (!key) return;
+
+        // clear search highlight
+        let vim = cm.state.vim;
+        if (
+          key == "<Esc>" &&
+          !vim.insertMode &&
+          !vim.visualMode &&
+          this.query /* && !cm.inMultiSelectMode*/
+        ) {
+          cm.removeOverlay(null);
+        }
+
+        cm.state.vim.status = (cm.state.vim.status || "") + key;
+        let result = Vim.multiSelectHandleKey(cm, key, "user");
+
+        // insert mode
+        if (!result && cm.state.vim.insertMode && cm.state.overwrite) {
+          if (e.key && e.key.length == 1 && !/\n/.test(e.key)) {
+            result = true;
+            cm.overWriteSelection(e.key);
+          } else if (e.key == "Backspace") {
+            result = true;
+            CodeMirror.commands.cursorCharLeft(cm);
           }
         }
-      }
-    }
-
-    this.blockCursor.update(update);
-  }
-  updateClass() {
-    const state = this.cm.state;
-    if (!state.vim || (state.vim.insertMode && !state.overwrite))
-      this.view.scrollDOM.classList.remove("cm-vimMode")
-    else 
-      this.view.scrollDOM.classList.add("cm-vimMode")
-  }
-  updateStatus() {
-    let dom = this.cm.state.statusbar;
-    if (!dom) return;
-    let dialog = this.cm.state.dialog
-    let vim = this.cm.state.vim;
-    if (dialog) {
-      if (dialog.parentElement != dom) {
-        dom.textContent = ""
-        dom.appendChild(dialog)
-      }
-    } else {
-      dom.textContent = `--${(vim.mode || "normal").toUpperCase()}--`
-    }
-
-    this.dom.textContent = vim.status
-    dom.appendChild(this.dom)
-  }
-
-  destroy() {
-    this.cm.state.vim = null;
-    this.updateClass()
-    this.blockCursor.destroy();
-    delete (this.view as any).cm;
-  }
-
-  highlight(query: any) {
-    this.query = query;
-    if (!query) 
-      return this.decorations = Decoration.none
-    let {view} = this
-    let builder = new RangeSetBuilder<Decoration>()
-    for (let i = 0, ranges = view.visibleRanges, l = ranges.length; i < l; i++) {
-      let {from, to} = ranges[i]
-      while (i < l - 1 && to > ranges[i + 1].from - 2 * HighlightMargin) to = ranges[++i].to
-      query.highlight(view.state.doc, from, to, (from: number, to: number) => {
-        builder.add(from, to, matchMark)
-      })
-    }
-    return this.decorations = builder.finish()
-  }
-  query = null
-  decorations = Decoration.none
-
-}, {
-  eventHandlers: {
-    keydown: function(e: KeyboardEvent, view: EditorView) {
-      const key = CodeMirror.vimKey(e)
-      const cm = this.cm
-      if (!key) return
-      
-      // clear search highlight
-      let vim = cm.state.vim
-      if (key == "<Esc>"
-       && !vim.insertMode && !vim.visualMode 
-       && this.query/* && !cm.inMultiSelectMode*/
-      ) {
-        cm.removeOverlay(null);
-      }
-
-      cm.state.vim.status = (cm.state.vim.status|| "") + key
-      let result = Vim.multiSelectHandleKey(cm, key, "user");
-
-      // insert mode
-      if (!result && cm.state.vim.insertMode && cm.state.overwrite) {
-        if (e.key && e.key.length == 1 && !/\n/.test(e.key)) {
-          result = true;
-          cm.overWriteSelection(e.key)
-        } else if (e.key == "Backspace") {
-          result = true;
-          CodeMirror.commands.cursorCharLeft(cm)
+        if (result) {
+          e.preventDefault();
+          e.stopPropagation();
+          this.blockCursor.scheduleRedraw();
         }
-      }
-      if (result) {
-        e.preventDefault()
-        e.stopPropagation()
-        this.blockCursor.scheduleRedraw();
-      } 
 
-      this.updateStatus()
+        this.updateStatus();
 
-      return !!result;
-    }
-  },
-  
-  decorations: v => v.decorations
-})
+        return !!result;
+      },
+    },
 
-const matchMark = Decoration.mark({class: "cm-searchMatch"})
+    decorations: (v) => v.decorations,
+  }
+);
 
-const showVimPanel = StateEffect.define<boolean>()
+const matchMark = Decoration.mark({ class: "cm-searchMatch" });
+
+const showVimPanel = StateEffect.define<boolean>();
 
 const vimPanelState = StateField.define<boolean>({
   create: () => false,
   update(value, tr) {
-    for (let e of tr.effects) if (e.is(showVimPanel)) value = e.value
-    return value
+    for (let e of tr.effects) if (e.is(showVimPanel)) value = e.value;
+    return value;
   },
-  provide: f =>{
-    return showPanel.from(f, on => on ? createVimPanel : null)
-  }
-})
+  provide: (f) => {
+    return showPanel.from(f, (on) => (on ? createVimPanel : null));
+  },
+});
 
 function createVimPanel(view: EditorView) {
-  let dom = document.createElement("div")
-  dom.className = "cm-vim-panel"
+  let dom = document.createElement("div");
+  dom.className = "cm-vim-panel";
   let cm = (view as EditorViewExtended).cm;
   if (cm.state.dialog) {
-    dom.appendChild(cm.state.dialog)
+    dom.appendChild(cm.state.dialog);
   }
-  return {top: false, dom}
+  return { top: false, dom };
 }
 
 function statusPanel(view: EditorView): Panel {
-  let dom = document.createElement("div")
-  dom.className = "cm-vim-panel"
+  let dom = document.createElement("div");
+  dom.className = "cm-vim-panel";
   let cm = (view as EditorViewExtended).cm;
-  cm.state.statusbar = dom
-  cm.state.vimPlugin.updateStatus()
-  return {dom}
+  cm.state.statusbar = dom;
+  cm.state.vimPlugin.updateStatus();
+  return { dom };
 }
 
-export function vim(options: {status?: boolean} = {}): Extension {
+export function vim(options: { status?: boolean } = {}): Extension {
   return [
     vimStyle,
-    vimPlugin,
+    Prec.highest(vimPlugin),
     hideNativeSelection,
-    options.status ? showPanel.of(statusPanel): vimPanelState
-  ]
+    options.status ? showPanel.of(statusPanel) : vimPanelState,
+  ];
 }
 
-export {CodeMirror, Vim}
+export { CodeMirror, Vim };
 
-export function getCM(view: EditorView): CodeMirror|null {
+export function getCM(view: EditorView): CodeMirror | null {
   return (view as EditorViewExtended).cm || null;
 }
+


### PR DESCRIPTION
Reverts relevant changes introduced in https://github.com/replit/codemirror-vim/pull/25.
 
We shouldn't be sidestepping the CM6 API and using raw DOM event handlers since that makes cooperating with other extensions/keymaps less predictable. See discussion in above PR.