### PR TITLE
Add fix for search highlights not appearing when searching for same text consecutively

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -196,7 +196,11 @@ const vimPlugin = ViewPlugin.fromClass(
           !vim.visualMode &&
           this.query /* && !cm.inMultiSelectMode*/
         ) {
-          cm.removeOverlay(null);
+          const searchState = vim.searchState_
+          if (searchState) {
+            cm.removeOverlay(searchState.getOverlay())
+            searchState.setOverlay(null);
+          }
         }
 
         cm.state.vim.status = (cm.state.vim.status || "") + key;


### PR DESCRIPTION
This fixes the following bug:

1. Start the dev server and open in a browser
2. Place the cursor in the first instance of the word "import"
3. Press `*`. The cursor moves to the second "import" and all three instances of "import" are highlighted
4. Press `Esc`. Highlighting is removed
5. Press `*` again. The cursor correctly moves to the third "import" but no instances of "import" are highlighted. They should be highlighted.

The fix makes use of the `searchState_` property of the `vim` object, which is clearly intended to be private. However, the `getSearchState()` method, which would be the ideal way to get the search state, is not accessible outside `vim.js`. I think a better solution would be to modify `vim.js` to expose `getSearchState()` but I didn't want to cause it to have to be updated in CM5 too.