### PR TITLE
Fix cursor on emojis

### DIFF
--- a/dev/index.ts
+++ b/dev/index.ts
@@ -7,7 +7,7 @@ import { Vim, vim } from "../src/"
 import * as commands from "@codemirror/commands";
 import { Compartment, EditorState } from '@codemirror/state';
 
-const doc = `
+const doc = `//🌞
 import { basicSetup, EditorView } from 'codemirror'
 import { javascript } from '@codemirror/lang-javascript';
 import { vim } from "../src/"

--- a/src/block-cursor.ts
+++ b/src/block-cursor.ts
@@ -148,7 +148,7 @@ function measureCursor(cm: CodeMirror, view: EditorView, cursor: SelectionRange,
   }
 
   if (fatCursor) {
-    let pos = view.coordsAtPos(head, cursor.assoc || 1);
+    let pos = view.coordsAtPos(head, 1);
     if (!pos) return null;
     let base = getBase(view);
     let domAtPos = view.domAtPos(head);

--- a/src/block-cursor.ts
+++ b/src/block-cursor.ts
@@ -158,11 +158,15 @@ function measureCursor(cm: CodeMirror, view: EditorView, cursor: SelectionRange,
       domAtPos = {node: domAtPos.node.childNodes[domAtPos.offset], offset: 0};
     }
     if (!(node instanceof HTMLElement)) {
+      if (!node.parentNode) return null;
       node = node.parentNode;
     }
     let style = getComputedStyle(node as HTMLElement);
     let letter = head < view.state.doc.length && view.state.sliceDoc(head, head + 1);
     if (!letter || letter == "\n" || letter == "\r") letter = "\xa0";
+    else if ((/[\uD800-\uDC00]/.test(letter) && head < view.state.doc.length - 1)) {
+      letter += view.state.sliceDoc(head + 1, head + 2);
+    }
     let h = (pos.bottom - pos.top);
     return new Piece(pos.left - base.left, pos.top - base.top + h * (1 - hCoeff), h * hCoeff,
                      style.fontFamily, style.fontSize, style.fontWeight, style.color,

--- a/src/block-cursor.ts
+++ b/src/block-cursor.ts
@@ -164,7 +164,8 @@ function measureCursor(cm: CodeMirror, view: EditorView, cursor: SelectionRange,
     let style = getComputedStyle(node as HTMLElement);
     let letter = head < view.state.doc.length && view.state.sliceDoc(head, head + 1);
     if (!letter || letter == "\n" || letter == "\r") letter = "\xa0";
-    else if ((/[\uD800-\uDC00]/.test(letter) && head < view.state.doc.length - 1)) {
+    else if ((/[\uD800-\uDBFF]/.test(letter) && head < view.state.doc.length - 1)) {
+      // include the second half of a surrogate pair in cursor
       letter += view.state.sliceDoc(head + 1, head + 2);
     }
     let h = (pos.bottom - pos.top);

--- a/src/vim.js
+++ b/src/vim.js
@@ -2969,16 +2969,14 @@ export function initVim(CodeMirror) {
       var includeLineBreak = vim.insertMode || vim.visualMode;
       var line = Math.min(Math.max(cm.firstLine(), cur.line), cm.lastLine() );
       var text = cm.getLine(line);
-      var maxCh = text.length - 1 + !!includeLineBreak;
+      var maxCh = text.length - 1 + Number(!!includeLineBreak);
       var ch = Math.min(Math.max(0, cur.ch), maxCh);
       // prevent cursor from entering surrogate pair
       var charCode = text.charCodeAt(ch);
-      if (0xDC00 < charCode && charCode <0xDFFF) {
+      if (0xDC00 <= charCode && charCode <= 0xDFFF) {
         var direction = 1;
-        if (oldCur && oldCur.line == line) {
-          if (oldCur.ch > ch) {
-            direction = -1;
-          }
+        if (oldCur && oldCur.line == line && oldCur.ch > ch) {
+          direction = -1;
         }
         ch +=direction;
         if (ch > maxCh) ch -=2;


### PR DESCRIPTION
- fixes cursor displaying � when placed over emoji
- fixes a bug of vim placing cursor inside emojis and other surrogate pairs
- fixes cursor bug described in the following comment https://github.com/replit/codemirror-vim/issues/38#issuecomment-1201072187