### PR TITLE
Change key handler to use CM6 keymap

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@codemirror/language": "^6.1.0",
     "@codemirror/search": "^6.2.0",
     "@codemirror/state": "^6.0.1",
-    "@codemirror/view": "^6.0.3"
+    "@codemirror/view": "^6.3.0"
   },
   "devDependencies": {
     "codemirror": "6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1055,9 +1055,9 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 selenium-webdriver@^4.0.0-beta.3:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.4.0.tgz#3f280504f6c0ac64a24b176304213b5a49ec2553"
-  integrity sha512-Du+/xfpvNi9zHAeYgXhOWN9yH0hph+cuX+hHDBr7d+SbtQVcfNJwBzLsbdHrB1Wh7MHXFuIkSG88A9TRRQUx3g==
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.5.0.tgz#7e20d0fc038177970dad81159950c12f7411ac0d"
+  integrity sha512-9mSFii+lRwcnT2KUAB1kqvx6+mMiiQHH60Y0VUtr3kxxi3oZ3CV3B8e2nuJ7T4SPb+Q6VA0swswe7rYpez07Bg==
   dependencies:
     jszip "^3.10.0"
     tmp "^0.2.1"


### PR DESCRIPTION
This PR changes the key handling to use a keymap with a single keybinding with the [any](https://codemirror.net/docs/ref/#view.KeyBinding.any) method, which is new in `@codemirror/view` 6.3.0.

This means that rather than the current situation where the Vim key handler runs before any CM6 keymap, the Vim key handler is a regular keymap and participates in the precedence hierarchy with other keymaps. I'm not aware of any current issues this will fix but it makes it possible to override Vim keybindings with a higher-precedence keymap, which was not possible before and is a definite improvement.

I've done some testing and haven't spotted any problems with the default set-up. However, this has the potential to break existing installations with other keymaps, because a keymap that currently always only runs after the Vim key handler may now have higher precedence and run before it instead, so I think there should probably be a note in the README and possibly a minor version number bump.

Background: https://discuss.codemirror.net/t/autocompletion-keymap-precedence-again/4827

Equivalent Emacs keybindings PR: https://github.com/replit/codemirror-emacs/pull/5