### PR TITLE
fixed noremap adding same mapping over and over and not adding other mappings

### DIFF
--- a/src/vim.js
+++ b/src/vim.js
@@ -788,6 +788,8 @@ export function initVim(CodeMirror) {
               newMapping.context = ctx;
             }
             // Add it to the keymap with a higher priority than the original.
+            // BUG: this adds at the beginning of defaultKeymaps!
+            //      so from this point on the i-th element will be the same
             this._mapCommand(newMapping);
             // Record the mapped contexts as complete.
             var mappedCtxs = toCtxArray(mapping.context);

--- a/src/vim.js
+++ b/src/vim.js
@@ -768,6 +768,7 @@ export function initVim(CodeMirror) {
         var ctxsToMap = toCtxArray(ctx);
         // Look through all actual defaults to find a map candidate.
         var actualLength = defaultKeymap.length, origLength = defaultKeymapLength;
+        var goodMappings = []
         for (var i = actualLength - origLength;
              i < actualLength && ctxsToMap.length;
              i++) {
@@ -787,14 +788,16 @@ export function initVim(CodeMirror) {
             if (ctx && !newMapping.context) {
               newMapping.context = ctx;
             }
-            // Add it to the keymap with a higher priority than the original.
-            // BUG: this adds at the beginning of defaultKeymaps!
-            //      so from this point on the i-th element will be the same
-            this._mapCommand(newMapping);
+            // Add it to the list of keymaps to add
+            goodMappings.unshift(newMapping);
             // Record the mapped contexts as complete.
             var mappedCtxs = toCtxArray(mapping.context);
             ctxsToMap = ctxsToMap.filter(function(el) { return mappedCtxs.indexOf(el) === -1; });
           }
+        }
+        for (var newMapping of goodMappings){
+          // Add new mappings with a higher priority than the originals.
+          this._mapCommand(newMapping);
         }
         // TODO: Create non-recursive keyToKey mappings for the unmapped contexts once those exist.
       },

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -4971,6 +4971,21 @@ testVim('noremap', function(cm, vim, helpers) {
   // unmap all mappings
   CodeMirror.Vim.mapclear();
 }, { value: 'wOrd1' });
+// noremap should capture all mappings of the rhs 
+testVim('noremap_all_mappings', function(cm, vim, helpers) {
+  // mapping to 'u' should undo in normal mode and lowercase in visual mode
+  CodeMirror.Vim.noremap('a', 'u');
+  helpers.doKeys('y', 'y', 'p');
+  eq('HeY\nHeY', cm.getValue());
+  // undo
+  helpers.doKeys('a');
+  eq('HeY', cm.getValue());
+  // lowercase
+  helpers.doKeys('V', 'a');
+  eq('hey', cm.getValue());
+  // unmap all mappings
+  CodeMirror.Vim.mapclear();
+}, { value: 'HeY' });
 testVim('noremap_swap', function(cm, vim, helpers) {
   CodeMirror.Vim.noremap('i', 'a', 'normal');
   CodeMirror.Vim.noremap('a', 'i', 'normal');


### PR DESCRIPTION
# Why

<!--
 - Describe what prompted you to make the change
 - It should be a good historical record of the motivations and context of the PR
-->

# What changed

<!--
 - Describe what changed to a level of detail that someone with little context with your PR could be able to review it.
 - People from the future should also be able to read this and understand what's going on.
 - Annotate changes with a self-review where necessary.
 - Post a screenshot or video when relevant
-->
I noticed that noremap was adding a _lot_ of remappings... and they were the same one! Upon closer inspection I realized the problem was that each time a matching mapping was found (the `if` on line 776 of `vim.js`) the mapping was added _at the top_ of the `defaultKeymap` list _while_ it was being iterated, which resulted in the iteration going back to the same element, noticing it still matches and adding it again.

This had an additional negative side effect of never adding the other mappings that match. 

I then designed a test case to demonstrate that this bug was causing undesired effects, and implemented a solution by delaying the addition of the newMappings until after the iteration is over.
