### PR TITLE
fix diw behavior for whitespace

### DIFF
--- a/src/vim.js
+++ b/src/vim.js
@@ -1490,12 +1490,12 @@ export function initVim(CodeMirror) {
             break;
           case 'wordUnderCursor':
             var word = expandWordUnderCursor(cm, false /** inclusive */,
-                true /** forward */, false /** bigWord */,
+                false /** innerWord */, false /** bigWord */,
                 true /** noSymbol */);
             var isKeyword = true;
             if (!word) {
               word = expandWordUnderCursor(cm, false /** inclusive */,
-                  true /** forward */, false /** bigWord */,
+                  false /** innerWord */, false /** bigWord */,
                   false /** noSymbol */);
               isKeyword = false;
             }
@@ -2176,10 +2176,10 @@ export function initVim(CodeMirror) {
         } else if (selfPaired[character]) {
           tmp = findBeginningAndEnd(cm, head, character, inclusive);
         } else if (character === 'W') {
-          tmp = expandWordUnderCursor(cm, inclusive, true /** forward */,
+          tmp = expandWordUnderCursor(cm, inclusive, !inclusive /** innerWord */,
                                                      true /** bigWord */);
         } else if (character === 'w') {
-          tmp = expandWordUnderCursor(cm, inclusive, true /** forward */,
+          tmp = expandWordUnderCursor(cm, inclusive, !inclusive /** innerWord */,
                                                      false /** bigWord */);
         } else if (character === 'p') {
           tmp = findParagraph(cm, head, motionArgs.repeat, 0, inclusive);
@@ -2207,8 +2207,10 @@ export function initVim(CodeMirror) {
             start = {line: start.line, ch: start.ch + 1}
           }
           tmp = {start: start, end: end};
-        } else {
-          // No text object defined for this, don't move.
+        }
+
+        if (!tmp) {
+          // No valid text object, don't move.
           return null;
         }
 
@@ -3449,7 +3451,7 @@ export function initVim(CodeMirror) {
       return firstNonWS == -1 ? text.length : firstNonWS;
     }
 
-    function expandWordUnderCursor(cm, inclusive, _forward, bigWord, noSymbol) {
+    function expandWordUnderCursor(cm, inclusive, innerWord, bigWord, noSymbol) {
       var cur = getHead(cm);
       var line = cm.getLine(cur.line);
       var idx = cur.ch;
@@ -3457,17 +3459,21 @@ export function initVim(CodeMirror) {
       // Seek to first word or non-whitespace character, depending on if
       // noSymbol is true.
       var test = noSymbol ? wordCharTest[0] : bigWordCharTest [0];
-      while (!test(line.charAt(idx))) {
-        idx++;
-        if (idx >= line.length) { return null; }
-      }
-
-      if (bigWord) {
-        test = bigWordCharTest[0];
+      if (innerWord && /\s/.test(line.charAt(idx))) {
+        test = function(ch) { return /\s/.test(ch); };
       } else {
-        test = wordCharTest[0];
-        if (!test(line.charAt(idx))) {
-          test = wordCharTest[1];
+        while (!test(line.charAt(idx))) {
+          idx++;
+          if (idx >= line.length) { return null; }
+        }
+
+        if (bigWord) {
+          test = bigWordCharTest[0];
+        } else {
+          test = wordCharTest[0];
+          if (!test(line.charAt(idx))) {
+            test = wordCharTest[1];
+          }
         }
       }
 

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1493,6 +1493,9 @@ testEdit('diw_end_spc', 'foo \tbAr', /A/, 'diw', 'foo \t');
 testEdit('daw_end_spc', 'foo \tbAr', /A/, 'daw', 'foo');
 testEdit('diw_end_punct', 'foo \tbAr.', /A/, 'diw', 'foo \t.');
 testEdit('daw_end_punct', 'foo \tbAr.', /A/, 'daw', 'foo.');
+testEdit('diw_space_word1', 'foo \t\n\tbar.', /\t/, 'diw', 'foo\n\tbar.');
+testEdit('diw_space_word2', 'foo +bar.', / /, 'diw', 'foo+bar.');
+testEdit('diw_space_word3', ' foo bar.', / /, 'diw', 'foo bar.');
 // Big word:
 testEdit('diW_mid_spc', 'foo \tbAr\t baz', /A/, 'diW', 'foo \t\t baz');
 testEdit('daW_mid_spc', 'foo \tbAr\t baz', /A/, 'daW', 'foo \tbaz');
@@ -1508,6 +1511,7 @@ testEdit('diW_end_spc', 'foo \tbAr', /A/, 'diW', 'foo \t');
 testEdit('daW_end_spc', 'foo \tbAr', /A/, 'daW', 'foo');
 testEdit('diW_end_punct', 'foo \tbAr.', /A/, 'diW', 'foo \t');
 testEdit('daW_end_punct', 'foo \tbAr.', /A/, 'daW', 'foo');
+testEdit('diW_space_word2', 'foo +bar.', / /, 'diW', 'foo+bar.');
 // Deleting text objects
 //    Open and close on same line
 testEdit('di(_open_spc', 'foo (bAr) baz', /\(/, 'di(', 'foo () baz');


### PR DESCRIPTION
fixes https://github.com/replit/codemirror-vim/issues/76

diw on whitespace is supposed to delete the whitespace, also adds a check to not throw when text object returns null.
