### PR TITLE
fix ex commands without line arguments

### DIFF
--- a/src/cm_adapter.ts
+++ b/src/cm_adapter.ts
@@ -347,7 +347,7 @@ export class CodeMirror {
     if (!updates) return null;
     var offset = handle.index;
     for (var i = 0; i < updates.length; i++) {
-      offset = updates[i].changes .mapPos(offset)
+      offset = updates[i].changes .mapPos(offset, 1, MapMode.TrackAfter);
       if (offset == null) return null;
     }
     var pos = this.posFromIndex(offset);

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -4127,6 +4127,13 @@ testVim('ex_write', function(cm, vim, helpers) {
   }
   CodeMirror.commands.save = tmp;
 });
+testVim('ex_delete', function(cm, vim, helpers) {
+  helpers.doKeys("j");
+  helpers.doEx('delete');
+  eq('l 1\nl 3\nl 4\n', cm.getValue());
+  helpers.doEx('d');
+  eq('l 1\nl 4\n', cm.getValue());
+}, { value: 'l 1\nl 2\nl 3\nl 4\n'});
 testVim('ex_sort', function(cm, vim, helpers) {
   helpers.doEx('sort');
   eq('Z\na\nb\nc\nd', cm.getValue());


### PR DESCRIPTION
fixes an edgecase of https://github.com/replit/codemirror-vim/issues/62 for running `:d` without any arguments