### PR TITLE
implement C-O in insert mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,9 @@ const vimPlugin = ViewPlugin.fromClass(
         }
       } else {
         dom.textContent = ""
-        this.statusButton.textContent = `--${(vim.mode || "normal").toUpperCase()}--`;
+        var status = (vim.mode || "normal").toUpperCase();
+        if (vim.insertModeReturn) status += "(C-O)"
+        this.statusButton.textContent = `--${status}--`;
         dom.appendChild(this.statusButton);
       }
 

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1712,6 +1712,16 @@ testVim('<C-x>/<C-a> search forward', function(cm, vim, helpers) {
     helpers.assertCursorAt(0, 11);
   });
 }, {value: '__jmp1 jmp2 jmp'});
+testVim('insert_ctrl_o', function(cm, vim, helpers) {
+  helpers.doKeys('i');
+  is(vim.insertMode);
+  helpers.doKeys('<C-o>');
+  is(!vim.insertMode);
+  helpers.doKeys('3', 'w');
+  is(vim.insertMode);
+  eqCursorPos(makeCursor(0, 14), cm.getCursor());
+  eq('vim-insert', cm.getOption('keyMap'));
+}, { value: 'one two three here' });
 testVim('insert_ctrl_u', function(cm, vim, helpers) {
   var curStart = makeCursor(0, 10);
   cm.setCursor(curStart);


### PR DESCRIPTION
fixes https://github.com/replit/codemirror-vim/issues/84

https://raw.githack.com/replit/codemirror-vim/insert-C-O/dev/web-demo.html

The status change wouldn't automatically apply to replit, so some rethinking of the way status bar is handled may be needed