### PR TITLE
 Make unfocused block cursor content transparent to prevent character overlay

### DIFF
--- a/src/block-cursor.ts
+++ b/src/block-cursor.ts
@@ -121,7 +121,8 @@ export class BlockCursorPlugin {
   },
   "&:not(.cm-focused) .cm-fat-cursor": {
     background: "none",
-    outline: "solid 1px #ff9696"
+    outline: "solid 1px #ff9696",
+    color: "transparent !important",
   },
 }
 


### PR DESCRIPTION
# Why

<!--
 - Describe what prompted you to make the change
 - It should be a good historical record of the motivations and context of the PR
-->
An unfocused cursor overlays a copy of the character such that both are visible, making the character look stronger:
![strong_m](https://user-images.githubusercontent.com/158919/220490914-9db0bef7-a4c0-4fa7-9ffc-8501c171baa9.png)



# What changed

<!--
 - Describe what changed to a level of detail that someone with little context with your PR could be able to review it.
 - People from the future should also be able to read this and understand what's going on.
 - Annotate changes with a self-review where necessary.
 - Post a screenshot or video when relevant
-->
I've made the colour of the content of an unfocused block cursor transparent:
![normal_m](https://user-images.githubusercontent.com/158919/220491500-44dbf09a-9e78-4989-b43b-9118e1250381.png)

# Test plan

<!-- 
 - Test plans should allow people without context to run through a list of steps and assert behavior.
 - If this is a bug fix, the test plan should include steps to reproduce the problem.
 - If this is a feature, the test plan should reflect a human-readable end-to-end test.
-->
1. View the dev page in a browser.
2. Place the cursor over a letter. Click outside the editor. Look closely at the letter inside the cursor.
