### PR TITLE
fix ci" for two strings on same line

### DIFF
--- a/src/vim.js
+++ b/src/vim.js
@@ -4323,13 +4323,16 @@ export function initVim(CodeMirror) {
       // then move the cursor forward
       if (cur.ch < firstIndex) {
         cur.ch = firstIndex;
-        // Why is this line even here???
-        // cm.setCursor(cur.line, firstIndex+1);
       }
       // otherwise if the cursor is currently on the closing symbol
       else if (firstIndex < cur.ch && chars[cur.ch] == symb) {
-        end = cur.ch; // assign end to the current cursor
-        --cur.ch; // make sure to look backwards
+        var stringAfter = /string/.test(cm.getTokenTypeAt(offsetCursor(head, 0, 1)));
+        var stringBefore = /string/.test(cm.getTokenTypeAt(head));
+        var isStringStart = stringAfter && !stringBefore
+        if (!isStringStart) {
+          end = cur.ch; // assign end to the current cursor
+          --cur.ch; // make sure to look backwards
+        }
       }
 
       // if we're currently on the symbol, we've got a start

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1619,6 +1619,18 @@ testSelection('viw_eol', 'foo \tbAr', /r/, 'viw', 'bAr');
 testSelection('vi{_middle_spc', 'a{\n\tbar\n\t}b', /r/, 'vi{', '\n\tbar\n\t');
 testSelection('va{_middle_spc', 'a{\n\tbar\n\t}b', /r/, 'va{', '{\n\tbar\n\t}');
 
+testVim('ci" for two strings', function(cm, vim, helpers) {
+  cm.setCursor(0, 11);
+  helpers.doKeys('c', 'i', '"');
+  eq('   "":  "string2";', cm.getValue());
+  helpers.doKeys('<Esc>', 'u', 'f', '"', '<Right>');
+  helpers.doKeys('c', 'i', '"');
+  eq('   "string1""string2";', cm.getValue());
+  helpers.doKeys('<Esc>', 'u', 'f', '"');
+  helpers.doKeys('c', 'i', '"');
+  eq('   "string1":  "";', cm.getValue());
+}, {value: '   "string1":  "string2";'});
+
 testVim('mouse_select', function(cm, vim, helpers) {
   cm.setSelection(new Pos(0, 2), new Pos(0, 4), {origin: '*mouse'});
   is(cm.state.vim.visualMode);


### PR DESCRIPTION
Fixes https://github.com/replit/codemirror-vim/issues/80 by checking syntax highlighting to decide if the quote is at the beginning of string or at the end.

@sergeichestakov this behavior is different from vim, which simply counts the number of quotes, but i think this is better. 
I'll add tests to this pull request if you agree that this is the desired behavior.

https://raw.githack.com/replit/codemirror-vim/fix-ci-quote/dev/web-demo.html