### PR TITLE
safari fires composition event before keydown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -266,6 +266,9 @@ const vimPlugin = ViewPlugin.fromClass(
           }
         });
       },
+      compositionstart: function(e: Event, view: EditorView) {
+        this.useNextTextInput = true;
+      },
       keypress: function(e: KeyboardEvent, view: EditorView) {
         if (this.lastKeydown == "Dead")
           this.handleKey(e, view);


### PR DESCRIPTION
Fixes https://github.com/replit/codemirror-vim/issues/91

https://raw.githack.com/replit/codemirror-vim/safari-french-keyboard/dev/web-demo.html