### PR TITLE
Block text object

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -7,7 +7,7 @@
     <style>
       #editor {
         height: min(540px, 50vh); width: min(960px, 90vw);
-        position: absolute; resize: both; overflow: hidden
+        resize: both; overflow: hidden
       }
       #editor>.cm-editor {width: 100%; height: 100%}
       #editor.split>.cm-editor {height: 50%}
@@ -17,5 +17,9 @@
     <div id="toolbar"></div>
     <div id="editor"></div>
     <script type="module" src="./index.ts"></script>
+    <br>
+    <br>
+    <a href="./test.html">tests</a><br>
+    <a href="./cm5/index.html">cm5 demo</a>
   </body>
 </html>

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -59,7 +59,16 @@ var options = {
   }),
 };
 
-
+var focusEditorButton = document.createElement("button");
+focusEditorButton.onclick = function(e) {
+  e.preventDefault();
+  view?.focus();
+}
+focusEditorButton.textContent = "focusEditor";
+focusEditorButton.onmousedown = function(e) {
+  e.preventDefault();
+}
+document.getElementById("toolbar")?.append(focusEditorButton," ")
   
  
 let global = window as any;

--- a/src/block-cursor.ts
+++ b/src/block-cursor.ts
@@ -11,6 +11,7 @@ class Piece {
               readonly fontSize: string,
               readonly fontWeight: string,
               readonly color: string,
+              readonly tabSize: string,
               readonly className: string,
               readonly letter: string,
               readonly partial: boolean) {}
@@ -31,6 +32,7 @@ class Piece {
     elt.style.fontSize = this.fontSize;
     elt.style.fontWeight = this.fontWeight;
     elt.style.color = this.partial ? "transparent" : this.color;
+    elt.style.tabSize = this.tabSize;
 
     elt.className = this.className;
     elt.textContent = this.letter;
@@ -176,7 +178,7 @@ function measureCursor(cm: CodeMirror, view: EditorView, cursor: SelectionRange,
     }
     let h = (pos.bottom - pos.top);
     return new Piece(pos.left - base.left, pos.top - base.top + h * (1 - hCoeff), h * hCoeff,
-                     style.fontFamily, style.fontSize, style.fontWeight, style.color,
+                     style.fontFamily, style.fontSize, style.fontWeight, style.color, style.tabSize,
                      primary ? "cm-fat-cursor cm-cursor-primary" : "cm-fat-cursor cm-cursor-secondary",
                      letter, hCoeff != 1)
   } else {

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1618,6 +1618,7 @@ testSelection('viw_end_spc', 'foo \tbAr\t baz', /r/, 'viw', 'bAr');
 testSelection('viw_eol', 'foo \tbAr', /r/, 'viw', 'bAr');
 testSelection('vi{_middle_spc', 'a{\n\tbar\n\t}b', /r/, 'vi{', '\n\tbar\n\t');
 testSelection('va{_middle_spc', 'a{\n\tbar\n\t}b', /r/, 'va{', '{\n\tbar\n\t}');
+testSelection('va{outside', 'xa{\n\tbar\n\t}b', /x/, 'va{', '{\n\tbar\n\t}');
 
 testVim('ci" for two strings', function(cm, vim, helpers) {
   cm.setCursor(0, 11);


### PR DESCRIPTION
fixes https://github.com/replit/codemirror-vim/issues/101 by changing text-object behavior to match with vim 9