### PR TITLE
implement :normal command

### DIFF
--- a/dev/index.ts
+++ b/dev/index.ts
@@ -202,3 +202,36 @@ function createView() {
 
 
 updateView()
+
+// save and  restor search history
+
+
+function saveHistory(name) {
+  var controller = Vim.getVimGlobalState_()[name];
+  var json = JSON.stringify(controller);
+  if (json.length > 10000) {
+    var toTrim = JSON.parse(json);
+    toTrim.historyBuffer = toTrim.historyBuffer.slice(toTrim.historyBuffer.lenght/2);
+    toTrim.iterator = toTrim.historyBuffer.lenght;
+    json = JSON.stringify(toTrim);
+  }
+  localStorage[name] = json;
+}
+function restoreHistory(name) {
+  try {
+    var json = JSON.parse(localStorage[name]);
+    var controller = Vim.getVimGlobalState_()[name];
+    controller.historyBuffer = json.historyBuffer.filter(x => typeof x == "string" && x)
+    controller.iterator = Math.min(parseInt(json.iterator) || Infinity, controller.historyBuffer.length)
+  } catch(e) {
+
+  }
+}
+
+restoreHistory('exCommandHistoryController');
+restoreHistory('searchHistoryController');
+
+window.onunload = function() {
+  saveHistory('exCommandHistoryController');
+  saveHistory('searchHistoryController');
+}

--- a/src/cm_adapter.ts
+++ b/src/cm_adapter.ts
@@ -126,7 +126,7 @@ function runHistoryCommand(cm: CodeMirror, revert: boolean) {
   }
 }
 
-var keys: any = {};
+var keys: Record<string, (cm: CodeMirror) => void> = {};
 "Left|Right|Up|Down|Backspace|Delete".split("|").forEach(key => {
   keys[key] = (cm:CodeMirror) => runScopeHandlers(cm.cm6, {key: key}, "editor");
 });

--- a/src/cm_adapter.ts
+++ b/src/cm_adapter.ts
@@ -1,6 +1,6 @@
 import { EditorSelection, Text, MapMode, ChangeDesc } from "@codemirror/state"
 import { StringStream, matchBrackets, indentUnit, ensureSyntaxTree, foldCode } from "@codemirror/language"
-import { EditorView, ViewUpdate } from "@codemirror/view"
+import { EditorView, runScopeHandlers, ViewUpdate } from "@codemirror/view"
 import { RegExpCursor, setSearchQuery, SearchQuery } from "@codemirror/search"
 import {
   insertNewlineAndIndent, indentMore, indentLess, indentSelection,
@@ -126,6 +126,11 @@ function runHistoryCommand(cm: CodeMirror, revert: boolean) {
   }
 }
 
+var keys: any = {};
+"Left|Right|Up|Down|Backspace|Delete".split("|").forEach(key => {
+  keys[key] = (cm:CodeMirror) => runScopeHandlers(cm.cm6, {key: key}, "editor");
+});
+
 export class CodeMirror {
   static isMac = typeof navigator != "undefined" && /Mac/.test(navigator.platform);
   // --------------------------
@@ -151,14 +156,7 @@ export class CodeMirror {
   static isWordChar = function (ch: string) {
     return wordChar.test(ch);
   };
-  static keys: any = {
-    Backspace: function (cm: CodeMirror) {
-      deleteCharBackward(cm.cm6);
-    },
-    Delete: function (cm: CodeMirror) {
-      deleteCharForward(cm.cm6);
-    }
-  };
+  static keys: any = keys;
   static keyMap = {
   };
   static addClass = function () { };

--- a/src/vim.js
+++ b/src/vim.js
@@ -286,6 +286,7 @@ export function initVim(CodeMirror) {
     { name: 'vglobal', shortName: 'v' },
     { name: 'delete', shortName: 'd' },
     { name: 'join', shortName: 'j' },
+    { name: 'normal', shortName: 'norm' },
     { name: 'global', shortName: 'g' }
   ];
 
@@ -350,6 +351,11 @@ export function initVim(CodeMirror) {
 
     var modifiers = {Shift:'S',Ctrl:'C',Alt:'A',Cmd:'D',Mod:'A',CapsLock:''};
     var specialKeys = {Enter:'CR',Backspace:'BS',Delete:'Del',Insert:'Ins'};
+    var vimToCmKeyMap = {};
+    'Left|Right|Up|Down|End|Home'.split('|').concat(Object.keys(specialKeys)).forEach(function(x) {
+      vimToCmKeyMap[(specialKeys[x] || '').toLowerCase()]
+         = vimToCmKeyMap[x.toLowerCase()] = x;
+    });
     function cmKeyToVimKey(key) {
       if (key.charAt(0) == '\'') {
         // Keypress character binding of format "'a'"
@@ -901,18 +907,6 @@ export function initVim(CodeMirror) {
             return true;
           }
         }
-        function doKeyToKey(keys) {
-          // TODO: prevent infinite recursion.
-          var match;
-          while (keys) {
-            // Pull off one command key, which is either a single character
-            // or a special sequence wrapped in '<' and '>', e.g. '<Space>'.
-            match = (/<\w+-.+?>|<\w+>|./).exec(keys);
-            key = match[0];
-            keys = keys.substring(match.index + key.length);
-            vimApi.handleKey(cm, key, 'mapping');
-          }
-        }
 
         function handleKeyInsertMode() {
           if (handleEsc()) { return true; }
@@ -1002,7 +996,7 @@ export function initVim(CodeMirror) {
               cm.curOp.isVimOp = true;
               try {
                 if (command.type == 'keyToKey') {
-                  doKeyToKey(command.toKeys);
+                  doKeyToKey(cm, command.toKeys, key);
                 } else {
                   commandDispatcher.processCommand(cm, vim, command);
                 }
@@ -1035,6 +1029,52 @@ export function initVim(CodeMirror) {
       exitVisualMode: exitVisualMode,
       exitInsertMode: exitInsertMode
     };
+
+    var keyToKeyStack = [];
+    function doKeyToKey(cm, keys, fromKey) {
+      // prevent infinite recursion.
+      if (fromKey) {
+        if (keyToKeyStack.indexOf(fromKey) != -1) return;
+        keyToKeyStack.push(fromKey);
+      }
+
+      try {
+        var vim = maybeInitVimState(cm);
+        var keyRe = /<(?:[CSMA]-)*\w+>|./gi;
+
+        var match;
+        // Pull off one command key, which is either a single character
+        // or a special sequence wrapped in '<' and '>', e.g. '<Space>'.
+        while ((match = keyRe.exec(keys))) {
+          var key = match[0];
+          var wasInsert = vim.insertMode;
+          var result = vimApi.handleKey(cm, key, 'mapping');
+
+          if (!result && wasInsert && vim.insertMode) {
+            if (key[0] == "<") {
+              var lowerKey = key.toLowerCase().slice(1, -1);
+              var parts = lowerKey.split('-');
+              var lowerKey = parts.pop();
+              if (lowerKey == 'lt') key = '<';
+              else if (lowerKey == 'space') key = ' ';
+              else if (lowerKey == 'cr') key = '\n';
+              else if (vimToCmKeyMap.hasOwnProperty(lowerKey)) {
+                // todo support codemirror  keys in insertmode vimToCmKeyMap
+                key = vimToCmKeyMap[lowerKey];
+                sendCmKey(cm, key);
+                continue;
+              } else {
+                key = key[0];
+                keyRe.lastIndex = match.index + 1;
+              }
+            }
+            cm.replaceSelection(key);
+          }
+        }
+      } finally {
+        keyToKeyStack.length = 0;
+      }
+    }
 
     // Represents the current input state.
     function InputState() {
@@ -5342,6 +5382,29 @@ export function initVim(CodeMirror) {
         // global inspects params.commandName
         this.global(cm, params);
       },
+      normal: function(cm, params) {
+        var argString = params.argString && params.argString.trimStart();
+        if (!argString) {
+          showConfirm(cm, 'Argument is required.');
+          return;
+        }
+        var line = params.line;
+        if (typeof line == 'number') {
+          var lineEnd = isNaN(params.lineEnd) ? line : params.lineEnd;
+          for (var i = line; i <= lineEnd; i++) {
+            cm.setCursor(i, 0);
+            doKeyToKey(cm, params.argString.trimStart());
+            if (cm.state.vim.insertMode) {
+              exitInsertMode(cm, true);
+            }
+          }
+        } else {
+          doKeyToKey(cm, params.argString.trimStart());
+          if (cm.state.vim.insertMode) {
+            exitInsertMode(cm, true);
+          }
+        }
+      },
       global: function(cm, params) {
         // a global command is of the form
         // :[range]g/pattern/[cmd]
@@ -6018,15 +6081,17 @@ export function initVim(CodeMirror) {
       macroModeState.isPlaying = false;
     }
 
-    function repeatInsertModeChanges(cm, changes, repeat) {
-      function keyHandler(binding) {
+    function sendCmKey(cm, key) {
+      CodeMirror.lookupKey(key, 'vim-insert', function keyHandler(binding) {
         if (typeof binding == 'string') {
           CodeMirror.commands[binding](cm);
         } else {
           binding(cm);
         }
         return true;
-      }
+      });
+    }
+    function repeatInsertModeChanges(cm, changes, repeat) {
       var head = cm.getCursor('head');
       var visualBlock = vimGlobalState.macroModeState.lastInsertModeChanges.visualBlock;
       if (visualBlock) {
@@ -6042,7 +6107,7 @@ export function initVim(CodeMirror) {
         for (var j = 0; j < changes.length; j++) {
           var change = changes[j];
           if (change instanceof InsertModeKey) {
-            CodeMirror.lookupKey(change.keyName, 'vim-insert', keyHandler);
+            sendCmKey(cm, change.keyName);
           } else if (typeof change == "string") {
             cm.replaceSelection(change);
           } else {

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -4268,6 +4268,15 @@ testVim('ex_global', function(cm, vim, helpers) {
   helpers.doEx('g/^ /');
   eq(' one one\n two one', helpers.getNotificationText());
 }, {value: 'one one\n one one\n one one'});
+testVim('ex_normal', function(cm, vim, helpers) {
+  cm.setCursor(0, 0);
+  helpers.doEx('g/one/normal    cw 1<lt>Esc><Esc>$i$');
+  helpers.doKeys("rt");
+  eq(' 1<Esc> on$e\nxx\n 1<Esc> on$e\n 1<Esc> on$t', cm.getValue());
+  helpers.doKeys('/', '<', '\n');
+  helpers.doKeys('x', 'x', 'p');
+  eq(' 1sEc> on$e\nxx\n 1<Esc> on$e\n 1<Esc> on$t', cm.getValue());
+}, {value: 'one one\nxx\none one\none one'});
 testVim('ex_global_substitute_join', function(cm, vim, helpers) {
   helpers.doEx('g/o/s/\\n/;');
   eq('one;two\nthree\nfour;five\n', cm.getValue());


### PR DESCRIPTION
one difference from vim is that we are reusing insert keymapping logic, so `<Esc>` in `:normal i some text <Esc> $` will work, without wrapping in `:exe`
To insert literal `<Esc>` as text, one can use `<lt>Esc>`.

This also fixes issue with imap not inserting text.

https://raw.githack.com/replit/codemirror-vim/2da2a13/dev/web-demo.html