### PR TITLE
Key matching fixes

### DIFF
--- a/src/vim.js
+++ b/src/vim.js
@@ -5368,7 +5368,12 @@ export function initVim(CodeMirror) {
         this.global(cm, params);
       },
       normal: function(cm, params) {
-        var argString = params.argString && params.argString.trimStart();
+        var argString = params.argString;
+        if (argString && argString[0] == '!') {
+            argString = argString.slice(1);
+            noremap = true;
+        }
+        argString = argString.trimStart();
         if (!argString) {
           showConfirm(cm, 'Argument is required.');
           return;

--- a/src/vim.js
+++ b/src/vim.js
@@ -1006,11 +1006,12 @@ export function initVim(CodeMirror) {
     var keyToKeyStack = [];
     var noremap = false;
     function doKeyToKey(cm, keys, fromKey) {
+      var noremapBefore = noremap;
       // prevent infinite recursion.
       if (fromKey) {
         if (keyToKeyStack.indexOf(fromKey) != -1) return;
         keyToKeyStack.push(fromKey);
-        noremap = fromKey.noremap;
+        noremap = fromKey.noremap != false;
       }
 
       try {
@@ -1029,7 +1030,7 @@ export function initVim(CodeMirror) {
             if (key[0] == "<") {
               var lowerKey = key.toLowerCase().slice(1, -1);
               var parts = lowerKey.split('-');
-              var lowerKey = parts.pop();
+              lowerKey = parts.pop() || '';
               if (lowerKey == 'lt') key = '<';
               else if (lowerKey == 'space') key = ' ';
               else if (lowerKey == 'cr') key = '\n';
@@ -1047,8 +1048,8 @@ export function initVim(CodeMirror) {
           }
         }
       } finally {
-        noremap = false;
-        keyToKeyStack.length = 0;
+        keyToKeyStack.pop();
+        noremap = keyToKeyStack.length ? noremapBefore : false;
       }
     }
 
@@ -5108,7 +5109,7 @@ export function initVim(CodeMirror) {
               keys: lhs,
               type: 'keyToKey',
               toKeys: rhs,
-              noremap: noremap
+              noremap: !!noremap
             };
             if (ctx) { mapping.context = ctx; }
             defaultKeymap.unshift(mapping);

--- a/src/vim.js
+++ b/src/vim.js
@@ -81,12 +81,12 @@ export function initVim(CodeMirror) {
     { keys: 'g<Up>', type: 'keyToKey', toKeys: 'gk' },
     { keys: 'g<Down>', type: 'keyToKey', toKeys: 'gj' },
     { keys: '<Space>', type: 'keyToKey', toKeys: 'l' },
-    { keys: '<BS>', type: 'keyToKey', toKeys: 'h', context: 'normal'},
-    { keys: '<Del>', type: 'keyToKey', toKeys: 'x', context: 'normal'},
+    { keys: '<BS>', type: 'keyToKey', toKeys: 'h'},
+    { keys: '<Del>', type: 'keyToKey', toKeys: 'x' },
     { keys: '<C-Space>', type: 'keyToKey', toKeys: 'W' },
-    { keys: '<C-BS>', type: 'keyToKey', toKeys: 'B', context: 'normal' },
+    { keys: '<C-BS>', type: 'keyToKey', toKeys: 'B' },
     { keys: '<S-Space>', type: 'keyToKey', toKeys: 'w' },
-    { keys: '<S-BS>', type: 'keyToKey', toKeys: 'b', context: 'normal' },
+    { keys: '<S-BS>', type: 'keyToKey', toKeys: 'b' },
     { keys: '<C-n>', type: 'keyToKey', toKeys: 'j' },
     { keys: '<C-p>', type: 'keyToKey', toKeys: 'k' },
     { keys: '<C-[>', type: 'keyToKey', toKeys: '<Esc>' },
@@ -3091,15 +3091,14 @@ export function initVim(CodeMirror) {
       // Partial matches are not applied. They inform the key handler
       // that the current key sequence is a subsequence of a valid key
       // sequence, so that the key buffer is not cleared.
-      var operatorPending = inputState.operator;
+      if (inputState.operator) context = "operatorPending";
       var match, partial = [], full = [];
       // if currently expanded key comes from a noremap, searcg only in default keys
       var startIndex = noremap ? keyMap.length - defaultKeymapLength : 0;
       for (var i = startIndex; i < keyMap.length; i++) {
         var command = keyMap[i];
         if (context == 'insert' && command.context != 'insert' ||
-            (command.context == "operatorPending" ? !operatorPending 
-              : command.context && command.context != context) ||
+            (command.context && command.context != context) ||
             inputState.operator && command.type == 'action' ||
             !(match = commandMatch(keys, command.keys))) { continue; }
         if (match == 'partial') { partial.push(command); }

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -4949,7 +4949,7 @@ testVim('ex_nmap', function(cm, vim, helpers) {
   eq(cm.getValue(), 'hello\nunfld');
   helpers.assertCursorAt(1, 3);
   helpers.doKeys('<Up>');
-  // helpers.assertCursorAt(0, 3);
+  helpers.assertCursorAt(0, 3);
   CodeMirror.Vim.mapclear();
 }, {value: 'hello\nunfair\nworld'});
 testVim('ex_imap', function(cm, vim, helpers) {

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -4935,6 +4935,23 @@ testVim('ex_omap', function(cm, vim, helpers) {
   eq(cm.getValue(), 'hello ');
   CodeMirror.Vim.mapclear();
 }, {value: 'hello unfair world'});
+testVim('ex_nmap', function(cm, vim, helpers) {
+  cm.setCursor(0, 3);
+  helpers.doEx('nmap k gj');
+  helpers.doKeys('k');
+  helpers.assertCursorAt(1, 3);
+  helpers.doKeys('d', 'k');
+  eq(cm.getValue(), 'world');
+  helpers.doKeys('u');
+  cm.setCursor(1, 3);
+  helpers.doEx('map k gj');
+  helpers.doKeys('d', 'k');
+  eq(cm.getValue(), 'hello\nunfld');
+  helpers.assertCursorAt(1, 3);
+  helpers.doKeys('<Up>');
+  // helpers.assertCursorAt(0, 3);
+  CodeMirror.Vim.mapclear();
+}, {value: 'hello\nunfair\nworld'});
 testVim('ex_imap', function(cm, vim, helpers) {
   CodeMirror.Vim.map('jk', '<Esc>', 'insert');
   helpers.doKeys('i');


### PR DESCRIPTION
fix part of https://github.com/replit/codemirror-vim/issues/111
this fixes `nmap j gj` applying in operator-pending mode,

issues of `map dj` not working, and `dVj` not forcing  linewiser mode still remain.