### PR TITLE
Implement `:startinsert`

### DIFF
--- a/src/vim.js
+++ b/src/vim.js
@@ -5578,8 +5578,8 @@ export function initVim(CodeMirror) {
         var cursor = cm.getSearchCursor(query, startPos);
         doReplace(cm, confirm, global, lineStart, lineEnd, cursor, query, replacePart, params.callback);
       },
-      startinsert: function(cm) {
-        actions.enterInsertMode(cm, { insertAt: params.argString=="!" ? 'charAfter' : "" }, cm.state.vim)
+      startinsert: function(cm, params) {
+        doKeyToKey(cm, params.argString == '!' ? 'A' : 'i', {});
       },
       redo: CodeMirror.commands.redo,
       undo: CodeMirror.commands.undo,

--- a/src/vim.js
+++ b/src/vim.js
@@ -291,6 +291,7 @@ export function initVim(CodeMirror) {
     { name: 'setglobal', shortName: 'setg' },
     { name: 'sort', shortName: 'sor' },
     { name: 'substitute', shortName: 's', possiblyAsync: true },
+    { name: 'startinsert', shortName: 'start' },
     { name: 'nohlsearch', shortName: 'noh' },
     { name: 'yank', shortName: 'y' },
     { name: 'delmarks', shortName: 'delm' },
@@ -5576,6 +5577,9 @@ export function initVim(CodeMirror) {
         var startPos = clipCursorToContent(cm, new Pos(lineStart, 0));
         var cursor = cm.getSearchCursor(query, startPos);
         doReplace(cm, confirm, global, lineStart, lineEnd, cursor, query, replacePart, params.callback);
+      },
+      startinsert: function(cm) {
+        actions.enterInsertMode(cm, { insertAt: params.argString=="!" ? 'charAfter' : "" }, cm.state.vim)
       },
       redo: CodeMirror.commands.redo,
       undo: CodeMirror.commands.undo,

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1315,6 +1315,7 @@ testVim('on_mode_change', async function(cm, vim, helpers) {
   test('v', 'visual');
   test(':', ''); // Event for Command-line mode not implemented.
   test('y\n', 'normal');
+  test(":startinsert", "insert")
 });
 
 // Swapcase commands edit in place and do not modify registers.

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1315,7 +1315,7 @@ testVim('on_mode_change', async function(cm, vim, helpers) {
   test('v', 'visual');
   test(':', ''); // Event for Command-line mode not implemented.
   test('y\n', 'normal');
-  test(":startinsert", "insert")
+  test(":startinsert", "insert");
 });
 
 // Swapcase commands edit in place and do not modify registers.
@@ -3486,6 +3486,21 @@ testVim('._insert', function(cm, vim, helpers) {
   eq('xy\nxy\ntestestt', cm.getValue());
   helpers.assertCursorAt(1, 1);
 }, { value: ''});
+testVim('._startinsert', function(cm, vim, helpers) {
+  helpers.doEx('map i x');
+  helpers.doKeys('i');
+  eq('', cm.getValue());
+  helpers.doEx('start');
+  helpers.doKeys('test');
+  helpers.doKeys('<Esc>');
+  helpers.doKeys('.');
+  eq('testestt', cm.getValue());
+  helpers.assertCursorAt(0, 6);
+  helpers.doEx('start!');
+  helpers.doKeys('xyz');
+  eq('testesttxyz', cm.getValue());
+  helpers.assertCursorAt(0, 11);
+}, { value: 'x'});
 testVim('._insert_repeat', function(cm, vim, helpers) {
   helpers.doKeys('i');
   helpers.doKeys('test')


### PR DESCRIPTION
# Why

An Obsidian.md plugin allows you to configure Obsidian's Vim support with a Vimrc-style config file. I want to be able to configure my Obsidian editor to enter insert mode automatically, which can be done in normal Vim by adding `startinsert` to `.vimrc`.

# What changed

<!--
 - Describe what changed to a level of detail that someone with little context with your PR could be able to review it.
 - People from the future should also be able to read this and understand what's going on.
 - Annotate changes with a self-review where necessary.
 - Post a screenshot or video when relevant
-->

Added support for the `startinsert` command, which puts the editor into insert mode when executed.

# Test plan

<!-- 
 - Test plans should allow people without context to run through a list of steps and assert behavior.
 - If this is a bug fix, the test plan should include steps to reproduce the problem.
 - If this is a feature, the test plan should reflect a human-readable end-to-end test.
-->

Attempt running `:startinsert` from inside of a CodeMirror Vim-enabled editor.
