### PR TITLE
use coordsForChar when available

### DIFF
--- a/src/block-cursor.ts
+++ b/src/block-cursor.ts
@@ -83,7 +83,7 @@ export class BlockCursorPlugin {
     for (let r of state.selection.ranges) {
       let prim = r == state.selection.main
       let piece = measureCursor(this.cm, this.view, r, prim)
-      if (piece) cursors.push(piece)      
+      if (piece) cursors.push(piece)
     }
     return {cursors}
   }
@@ -170,6 +170,11 @@ function measureCursor(cm: CodeMirror, view: EditorView, cursor: SelectionRange,
     }
     let style = getComputedStyle(node as HTMLElement);
     let left = pos.left;
+    // TODO remove coordsAtPos when all supported versions of codemirror have coordsForChar api
+    let charCoords = (view as any).coordsForChar?.(head);
+    if (charCoords) {
+      left = charCoords.left;
+    }
     if (!letter || letter == "\n" || letter == "\r") {
       letter = "\xa0";
     } else if (letter == "\t") {


### PR DESCRIPTION
fixes https://github.com/replit/codemirror-vim/issues/131 

requires the new version of codemirror as discussed at https://discuss.codemirror.net/t/is-there-a-way-to-get-left-coordinate-of-a-character/6891