### PR TITLE
Added Langmap Feature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -197,12 +197,15 @@ const vimPlugin = ViewPlugin.fromClass(
     decorations = Decoration.none;
     waitForCopy = false;
     handleKey(e: KeyboardEvent, view: EditorView) {
-      const key = CodeMirror.vimKey(e);
-      const cm = this.cm;
-      if (!key) return;
+      const rawKey = CodeMirror.vimKey(e);
+      if (!rawKey) return;
 
+      const cm = this.cm;
       let vim = cm.state.vim;
       if (!vim) return;
+
+      const key = vim.expectLiteralNext ? rawKey : Vim.langmapRemapKey(rawKey);
+
       // clear search highlight
       if (
         key == "<Esc>" &&

--- a/src/vim.js
+++ b/src/vim.js
@@ -312,7 +312,7 @@ export function initVim(CodeMirror) {
   updateLangmap('');
 
   // dvorak langmap for testing purposes:
-  updateLangmap("'q,\\,w,.e,pr,yt,fy,gu,ci,ro,lp,/[,=],aa,os,ed,uf,ig,dh,hj,tk,nl,s\\;,-',\\;z,qx,jc,kv,xb,bn,mm,w\\,,v.,z/,[-,]=,\"Q,<W,>E,PR,YT,FY,GU,CI,RO,LP,?{,+},AA,OS,ED,UF,IG,DH,HJ,TK,NL,S:,_\",:Z,QX,JC,KV,XB,BN,MM,W<,V>,Z?");
+  //updateLangmap("'q,\\,w,.e,pr,yt,fy,gu,ci,ro,lp,/[,=],aa,os,ed,uf,ig,dh,hj,tk,nl,s\\;,-',\\;z,qx,jc,kv,xb,bn,mm,w\\,,v.,z/,[-,]=,\"Q,<W,>E,PR,YT,FY,GU,CI,RO,LP,?{,+},AA,OS,ED,UF,IG,DH,HJ,TK,NL,S:,_\",:Z,QX,JC,KV,XB,BN,MM,W<,V>,Z?");
 
     function enterVimMode(cm) {
       cm.setOption('disableInput', true);
@@ -850,6 +850,9 @@ export function initVim(CodeMirror) {
             }
           }
         }
+      },
+      langmap: function(langmapString) {
+        updateLangmap(langmapString);
       },
       // TODO: Expose setOption and getOption as instance methods. Need to decide how to namespace
       // them, or somehow make them work with the existing CodeMirror setOption/getOption API.

--- a/src/vim.js
+++ b/src/vim.js
@@ -1149,7 +1149,10 @@ export function initVim(CodeMirror) {
 
     // langmap support
     function updateLangmap(langmapString, remapCtrl = true) {
-      if (langmap != null && langmap.string == langmapString) return;
+      if (langmap != null && langmap.string == langmapString) {
+        langmap.remapCtrl = remapCtrl;
+        return;
+      }
       langmap = parseLangmap(langmapString, remapCtrl);
     }
     function langmapIsLiteralMode(vim) {

--- a/src/vim.js
+++ b/src/vim.js
@@ -1219,15 +1219,8 @@ export function initVim(CodeMirror) {
 
       return { toQwerty: toQwerty, fromQwerty: fromQwerty, string: langmapString };
     }
-    function _langmapMap(map, key) {
-      return (key.length !== 1 || !(key in map)) ? key : map[key];
-
-    }
     function langmapRemapKey(key) {
-      return _langmapMap(langmap.toQwerty, key)
-    }
-    function langmapUnmapKey(key) {
-      return _langmapMap(langmap.fromQwerty, key)
+      return (key.length !== 1 || !(key in langmap.toQwerty)) ? key : langmap.toQwerty[key];
     }
 
     // Represents the current input state.

--- a/src/vim.js
+++ b/src/vim.js
@@ -851,6 +851,9 @@ export function initVim(CodeMirror) {
       langmap: function(langmapString, remapCtrl = true) {
         updateLangmap(langmapString, remapCtrl);
       },
+      langmapRemapKey: function(key) {
+        return langmapRemapKey(key);
+      },
       // TODO: Expose setOption and getOption as instance methods. Need to decide how to namespace
       // them, or somehow make them work with the existing CodeMirror setOption/getOption API.
       setOption: setOption,
@@ -883,10 +886,8 @@ export function initVim(CodeMirror) {
        * execute the bound command if a a key is matched. The function always
        * returns true.
        */
-      findKey: function(cm, rawKey, origin) {
+      findKey: function(cm, key, origin) {
         var vim = maybeInitVimState(cm);
-
-        let key = vim.expectLiteralNext ? rawKey : langmapRemapKey(rawKey);
 
         function handleMacroRecording() {
           var macroModeState = vimGlobalState.macroModeState;
@@ -2687,10 +2688,6 @@ export function initVim(CodeMirror) {
         cm.scrollTo(null, y);
       },
       replayMacro: function(cm, actionArgs, vim) {
-        // when replaying a macro, we must not "double remap" characters
-        const savedLangMap = langmap;
-        langmap = parseLangmap('');
-
         var registerName = actionArgs.selectedCharacter;
         var repeat = actionArgs.repeat;
         var macroModeState = vimGlobalState.macroModeState;
@@ -2702,9 +2699,6 @@ export function initVim(CodeMirror) {
         while(repeat--){
           executeMacroRegister(cm, vim, macroModeState, registerName);
         }
-
-        // restore langmap
-        langmap = savedLangMap;
       },
       enterMacroRecordMode: function(cm, actionArgs) {
         var macroModeState = vimGlobalState.macroModeState;

--- a/src/vim.js
+++ b/src/vim.js
@@ -1147,6 +1147,89 @@ export function initVim(CodeMirror) {
       }
     }
 
+    // langmap support
+    function updateLangmap(langmapString) {
+      if (langmap != null && langmap.string == langmapString) return;
+      langmap = parseLangmap(langmapString);
+    }
+    function langmapIsLiteralMode(vim) {
+      // Determine if keystrokes should be interpreted literally
+      return vim.insertMode;
+    }
+    function parseLangmap(langmapString) {
+      // From :help langmap
+      /*
+        The 'langmap' option is a list of parts, separated with commas.  Each
+            part can be in one of two forms:
+            1.  A list of pairs.  Each pair is a "from" character immediately
+                followed by the "to" character.  Examples: "aA", "aAbBcC".
+            2.  A list of "from" characters, a semi-colon and a list of "to"
+                characters.  Example: "abc;ABC"
+      */
+
+      // Step 0: Shortcut for empty langmap
+      let toQwerty = {};
+      let fromQwerty = {};
+      if (langmapString === '') return { toQwerty: toQwerty, fromQwerty: fromQwerty, string: '' };
+
+      // Step 1: Separate into parts.
+      // Technically the regex /(?<!(^|[^\\])\\(\\\\)*)\,/ should do the trick,
+      // but Javascript's implementation disagrees.
+      const separators = [...langmapString.matchAll(/(?<!(^|[^\\])\\(\\\\)*)\,|$/g)].map((x) => x.index);
+      const parts = separators.map((separatorIndex, arrayIndex) =>
+        langmapString.substring(
+          arrayIndex === 0 ? 0 : (separators[arrayIndex - 1]) + 1,
+          separatorIndex,
+        ),
+      );
+
+      // Step 2: Parse each part
+      function getEscaped(list) {
+        const characters = [];
+        let escaped = false;
+        for (const character of list) {
+          if (character === '\\') {
+            escaped = !escaped;
+            if (escaped) continue;
+          }
+          characters.push(character);
+        }
+        return characters;
+      }
+
+      for (const part of parts) {
+        const semicolon = [...part.matchAll(/(?<!(^|[^\\])\\(\\\\)*)\;/g)].map((x) => x.index);
+        if (semicolon.length > 1) continue; // skip over malformed part
+        if (semicolon.length === 0) {
+          // List of pairs of "from" and "to" characters
+          const pairs = getEscaped(part);
+          if (pairs.length % 2 !== 0) continue; // skip over malformed part
+          for (let i = 0; i < pairs.length; i += 2) toQwerty[pairs[i]] = pairs[i + 1];
+        } else {
+          // List of "from" characters and list of "to" characters
+          const from = getEscaped(part.substring(0, semicolon[0]));
+          const to = getEscaped(part.substring((semicolon[0]) + 1));
+          if (from.length !== to.length) continue; // skip over malformed part
+          for (let i = 0; i < from.length; ++i) toQwerty[from[i]] = to[i];
+        }
+      }
+
+      // Step 3: Reverse mapping
+      Object.fromEntries(Object.entries(toQwerty).map((x) => [x[1], x[0]])); 
+
+      return { toQwerty: toQwerty, fromQwerty: fromQwerty, string: langmapString };
+    }
+    function _langmapMap(map, key) {
+      return (key.length !== 1 || !(key in map)) ? key : map[key];
+
+    }
+    function langmapRemapKey(key) {
+      return _langmapMap(langmap.toQwerty, key)
+    }
+    function langmapUnmapKey(key) {
+      return _langmapMap(langmap.fromQwerty, key)
+    }
+
     // Represents the current input state.
     function InputState() {
       this.prefixRepeat = [];
@@ -6358,89 +6441,6 @@ export function initVim(CodeMirror) {
       return isHandled;
     }
     resetVimGlobalState();
-
-    // langmap support
-    function updateLangmap(langmapString) {
-      if (langmap != null && langmap.string == langmapString) return;
-      langmap = parseLangmap(langmapString);
-    }
-    function langmapIsLiteralMode(vim) {
-      // Determine if keystrokes should be interpreted literally
-      return vim.insertMode;
-    }
-    function parseLangmap(langmapString) {
-      // From :help langmap
-      /*
-        The 'langmap' option is a list of parts, separated with commas.  Each
-            part can be in one of two forms:
-            1.  A list of pairs.  Each pair is a "from" character immediately
-                followed by the "to" character.  Examples: "aA", "aAbBcC".
-            2.  A list of "from" characters, a semi-colon and a list of "to"
-                characters.  Example: "abc;ABC"
-      */
-
-      // Step 0: Shortcut for empty langmap
-      let toQwerty = {};
-      let fromQwerty = {};
-      if (langmapString === '') return { toQwerty: toQwerty, fromQwerty: fromQwerty, string: '' };
-
-      // Step 1: Separate into parts.
-      // Technically the regex /(?<!(^|[^\\])\\(\\\\)*)\,/ should do the trick,
-      // but Javascript's implementation disagrees.
-      const separators = [...langmapString.matchAll(/(?<!(^|[^\\])\\(\\\\)*)\,|$/g)].map((x) => x.index);
-      const parts = separators.map((separatorIndex, arrayIndex) =>
-        langmapString.substring(
-          arrayIndex === 0 ? 0 : (separators[arrayIndex - 1]) + 1,
-          separatorIndex,
-        ),
-      );
-
-      // Step 2: Parse each part
-      function getEscaped(list) {
-        const characters = [];
-        let escaped = false;
-        for (const character of list) {
-          if (character === '\\') {
-            escaped = !escaped;
-            if (escaped) continue;
-          }
-          characters.push(character);
-        }
-        return characters;
-      }
-
-      for (const part of parts) {
-        const semicolon = [...part.matchAll(/(?<!(^|[^\\])\\(\\\\)*)\;/g)].map((x) => x.index);
-        if (semicolon.length > 1) continue; // skip over malformed part
-        if (semicolon.length === 0) {
-          // List of pairs of "from" and "to" characters
-          const pairs = getEscaped(part);
-          if (pairs.length % 2 !== 0) continue; // skip over malformed part
-          for (let i = 0; i < pairs.length; i += 2) toQwerty[pairs[i]] = pairs[i + 1];
-        } else {
-          // List of "from" characters and list of "to" characters
-          const from = getEscaped(part.substring(0, semicolon[0]));
-          const to = getEscaped(part.substring((semicolon[0]) + 1));
-          if (from.length !== to.length) continue; // skip over malformed part
-          for (let i = 0; i < from.length; ++i) toQwerty[from[i]] = to[i];
-        }
-      }
-
-      // Step 3: Reverse mapping
-      Object.fromEntries(Object.entries(toQwerty).map((x) => [x[1], x[0]])); 
-
-      return { toQwerty: toQwerty, fromQwerty: fromQwerty, string: langmapString };
-    }
-    function _langmapMap(map, key) {
-      return (key.length !== 1 || !(key in map)) ? key : map[key];
-
-    }
-    function langmapRemapKey(key) {
-      return _langmapMap(langmap.toQwerty, key)
-    }
-    function langmapUnmapKey(key) {
-      return _langmapMap(langmap.fromQwerty, key)
-    }
 
   return vimApi;
 };

--- a/src/vim.js
+++ b/src/vim.js
@@ -245,8 +245,8 @@ export function initVim(CodeMirror) {
     { keys: '<C-t>', type: 'action', action: 'indent', actionArgs: { indentRight: true }, context: 'insert' },
     { keys: '<C-d>', type: 'action', action: 'indent', actionArgs: { indentRight: false }, context: 'insert' },
     // Text object motions
-    { keys: 'a<character>', type: 'motion', motion: 'textObjectManipulation' },
-    { keys: 'i<character>', type: 'motion', motion: 'textObjectManipulation', motionArgs: { textObjectInner: true }},
+    { keys: 'a<register>', type: 'motion', motion: 'textObjectManipulation' },
+    { keys: 'i<register>', type: 'motion', motion: 'textObjectManipulation', motionArgs: { textObjectInner: true }},
     // Search
     { keys: '/', type: 'search', searchArgs: { forward: true, querySrc: 'prompt', toJumplist: true }},
     { keys: '?', type: 'search', searchArgs: { forward: false, querySrc: 'prompt', toJumplist: true }},

--- a/src/vim.js
+++ b/src/vim.js
@@ -311,9 +311,6 @@ export function initVim(CodeMirror) {
   var langmap;
   updateLangmap('');
 
-  // dvorak langmap for testing purposes:
-  //updateLangmap("'q,\\,w,.e,pr,yt,fy,gu,ci,ro,lp,/[,=],aa,os,ed,uf,ig,dh,hj,tk,nl,s\\;,-',\\;z,qx,jc,kv,xb,bn,mm,w\\,,v.,z/,[-,]=,\"Q,<W,>E,PR,YT,FY,GU,CI,RO,LP,?{,+},AA,OS,ED,UF,IG,DH,HJ,TK,NL,S:,_\",:Z,QX,JC,KV,XB,BN,MM,W<,V>,Z?");
-
     function enterVimMode(cm) {
       cm.setOption('disableInput', true);
       cm.setOption('showCursorWhenSelecting', false);

--- a/src/vim.js
+++ b/src/vim.js
@@ -1167,60 +1167,31 @@ export function initVim(CodeMirror) {
                 characters.  Example: "abc;ABC"
       */
 
-      // Step 0: Shortcut for empty langmap
-      let toQwerty = {};
-      let fromQwerty = {};
-      if (langmapString === '') return { toQwerty: toQwerty, fromQwerty: fromQwerty, string: '' };
+      let keymap = {};
+      if (langmapString == '') return { keymap: keymap, string: '' };
 
-      // Step 1: Separate into parts.
-      // Technically the regex /(?<!(^|[^\\])\\(\\\\)*)\,/ should do the trick,
-      // but Javascript's implementation disagrees.
-      const separators = [...langmapString.matchAll(/(?<!(^|[^\\])\\(\\\\)*)\,|$/g)].map((x) => x.index);
-      const parts = separators.map((separatorIndex, arrayIndex) =>
-        langmapString.substring(
-          arrayIndex === 0 ? 0 : (separators[arrayIndex - 1]) + 1,
-          separatorIndex,
-        ),
-      );
-
-      // Step 2: Parse each part
       function getEscaped(list) {
-        const characters = [];
-        let escaped = false;
-        for (const character of list) {
-          if (character === '\\') {
-            escaped = !escaped;
-            if (escaped) continue;
-          }
-          characters.push(character);
-        }
-        return characters;
+        return list.split(/\\?(.)/).filter(Boolean);
       }
-
-      for (const part of parts) {
-        const semicolon = [...part.matchAll(/(?<!(^|[^\\])\\(\\\\)*)\;/g)].map((x) => x.index);
-        if (semicolon.length > 1) continue; // skip over malformed part
-        if (semicolon.length === 0) {
-          // List of pairs of "from" and "to" characters
+      langmapString.split(/((?:[^\\,]|\\.)+),/).map(part => {
+        if (!part) return;
+        const semicolon = part.split(/((?:[^\\;]|\\.)+);/);
+        if (semicolon.length == 3) {
+          const from = getEscaped(semicolon[1]);
+          const to = getEscaped(semicolon[2]);
+          if (from.length !== to.length) return; // skip over malformed part
+          for (let i = 0; i < from.length; ++i) keymap[from[i]] = to[i];
+        } else if (semicolon.length == 1) {
           const pairs = getEscaped(part);
-          if (pairs.length % 2 !== 0) continue; // skip over malformed part
-          for (let i = 0; i < pairs.length; i += 2) toQwerty[pairs[i]] = pairs[i + 1];
-        } else {
-          // List of "from" characters and list of "to" characters
-          const from = getEscaped(part.substring(0, semicolon[0]));
-          const to = getEscaped(part.substring((semicolon[0]) + 1));
-          if (from.length !== to.length) continue; // skip over malformed part
-          for (let i = 0; i < from.length; ++i) toQwerty[from[i]] = to[i];
+          if (pairs.length % 2 !== 0) return; // skip over malformed part
+          for (let i = 0; i < pairs.length; i += 2) keymap[pairs[i]] = pairs[i + 1];
         }
-      }
+      });
 
-      // Step 3: Reverse mapping
-      Object.fromEntries(Object.entries(toQwerty).map((x) => [x[1], x[0]])); 
-
-      return { toQwerty: toQwerty, fromQwerty: fromQwerty, string: langmapString };
+      return { keymap: keymap, string: langmapString };
     }
     function langmapRemapKey(key) {
-      return (key.length !== 1 || !(key in langmap.toQwerty)) ? key : langmap.toQwerty[key];
+      return (key.length !== 1 || !(key in langmap.keymap)) ? key : langmap.keymap[key];
     }
 
     // Represents the current input state.

--- a/src/vim.js
+++ b/src/vim.js
@@ -986,6 +986,7 @@ export function initVim(CodeMirror) {
             return true;
           }
           else if (match.type == 'clear') { clearInputState(cm); return true; }
+          vim.expectLiteralNext = false;
 
           vim.inputState.keyBuffer.length = 0;
           keysMatcher = /^(\d*)(.*)$/.exec(keys);

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -5633,6 +5633,34 @@ testVim('langmap_mark', function(cm, vim, helpers) {
   helpers.doKeys('-', '\'');
   helpers.assertCursorAt(2, 3);
 });
+// check that ctrl remapping works properly
+testVim('langmap_visual_block', function(cm, vim, helpers) {
+  CodeMirror.Vim.langmap(dvorakLangmap);
+
+  cm.setCursor(0, 1);
+  helpers.doKeys('<C-k>', '2', 'h', 'n', 'n', 'n', 'j');
+  helpers.doKeys('hello');
+  eq('1hello\n5hello\nahellofg', cm.getValue());
+  helpers.doKeys('<Esc>');
+  cm.setCursor(2, 3);
+  helpers.doKeys('<C-k>', '2', 't', 'd', 'J');
+  helpers.doKeys('world');
+  eq('1hworld\n5hworld\nahworld', cm.getValue());
+}, {value: '1234\n5678\nabcdefg'});
+// check that ctrl remapping can be disabled
+testVim('langmap_visual_block_no_ctrl_remap', function(cm, vim, helpers) {
+  CodeMirror.Vim.langmap(dvorakLangmap, false);
+
+  cm.setCursor(0, 1);
+  helpers.doKeys('<C-v>', '2', 'h', 'n', 'n', 'n', 'j');
+  helpers.doKeys('hello');
+  eq('1hello\n5hello\nahellofg', cm.getValue());
+  helpers.doKeys('<Esc>');
+  cm.setCursor(2, 3);
+  helpers.doKeys('<C-v>', '2', 't', 'd', 'J');
+  helpers.doKeys('world');
+  eq('1hworld\n5hworld\nahworld', cm.getValue());
+}, {value: '1234\n5678\nabcdefg'});
 
 
 async function delay(t) {


### PR DESCRIPTION
This pull request brings Vim's langmap feature over to CodeMirror. It resolves issue #145.

Short abstract of the reason behind this feature:
> The purpose of a langmap is to allow typing in insert and replace mode using one's preferred keyboard layout, while still being able to use standard Vim mappings in normal and visual mode. This is crucial for people using other scripts like Greek and Cyrillic or using a different keyboard layout like Dvorak that would spread default bindings throughout the whole keyboard.
>
> Example langmap for Greek:
> ```
> ΑA,ΒB,ΨC,ΔD,ΕE,ΦF,ΓG,ΗH,ΙI,ΞJ,ΚK,ΛL,ΜM,ΝN,ΟO,ΠP,QQ,ΡR,ΣS,ΤT,ΘU,ΩV,WW,ΧX,ΥY,ΖZ,αa,βb,ψc,δd,εe,φf,γg,ηh,ιi,ξj,κk,λl,μm,νn,οo,πp,qq,ρr,σs,τt,θu,ωv,ςw,χx,υy,ζz
> ```
>
> Example langmap for Dvorak:
> ```
> 'q,\\,w,.e,pr,yt,fy,gu,ci,ro,lp,/[,=],aa,os,ed,uf,ig,dh,hj,tk,nl,s\\;,-',\\;z,qx,jc,kv,xb,bn,mm,w\\,,v.,z/,[-,]=,\"Q,<W,>E,PR,YT,FY,GU,CI,RO,LP,?{,+},AA,OS,ED,UF,IG,DH,HJ,TK,NL,S:,_\",:Z,QX,JC,KV,XB,BN,MM,W<,V>,Z?
> ```
>
> You may find the exact format under ``:help langmap`` in Vim.

The `langmap(langmapString)` function has been added to the Vim API. Calling it parses the provided string as specified by Vim's `:help langmap`. Additionally, a few unit tests have been written.