### PR TITLE
Fix option values that include =

### DIFF
--- a/src/vim.js
+++ b/src/vim.js
@@ -5319,8 +5319,8 @@ export function initVim(CodeMirror) {
           return;
         }
         var expr = setArgs[0].split('=');
-        var optionName = expr[0];
-        var value = expr[1];
+        var optionName = expr.shift();
+        var value = expr.join('=');
         var forceGet = false;
         var forceToggle = false;
 

--- a/src/vim.js
+++ b/src/vim.js
@@ -5320,7 +5320,7 @@ export function initVim(CodeMirror) {
         }
         var expr = setArgs[0].split('=');
         var optionName = expr.shift();
-        var value = expr.join('=');
+        var value = expr.length > 0 ? expr.join('=') : undefined;
         var forceGet = false;
         var forceToggle = false;
 

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -4735,6 +4735,13 @@ testVim('ex_set_boolean', function(cm, vim, helpers) {
   helpers.doEx('set testoption!');
   is(!CodeMirror.Vim.getOption('testoption'));
 });
+// Make sure that langmap option is properly defined and "=" does not break option value parsing
+testVim('set_langmap', function(cm, vim, helpers) {
+  helpers.doEx('set langmap==j');
+  cm.setCursor(0, 0);
+  helpers.doKeys('=');
+  helpers.assertCursorAt(1,0);
+});
 testVim('set_string', function(cm, vim, helpers) {
   CodeMirror.Vim.defineOption('testoption', 'a', 'string');
   // Test default value is set.


### PR DESCRIPTION
# Why
Options that include `=` inside their value would break, in particular langmaps:
``set langmap=ab,cd,=e`` should remap `=` to `e`, instead the option value was cut early at `ab,cd,`.

# What changed
Merge all parts of the split string string but the first one using `=`.

# Test plan
- `:set langmap==j`
- `=`
- Evaluate whether the cursor has moved down by one line
