### PR TITLE
fix visual mode cursor shifted on empty lines

### DIFF
--- a/src/block-cursor.ts
+++ b/src/block-cursor.ts
@@ -158,7 +158,11 @@ function measureCursor(cm: CodeMirror, view: EditorView, cursor: SelectionRange,
     fatCursor = true;
     if (vim.visualBlock && !primary)
       return null;
-    if (cursor.anchor < cursor.head) head--;
+    if (cursor.anchor < cursor.head) {
+      let letter = head < view.state.doc.length && view.state.sliceDoc(head, head + 1);
+      if (letter != "\n")
+        head--;
+    }
     if (cm.state.overwrite) hCoeff = 0.2;
     else if (vim.status) hCoeff = 0.5;
   }

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -168,6 +168,7 @@ function testVim(name, run, opts, expectedFail) {
     var cm = CodeMirror(place, vimOpts);
     var vim = CodeMirror.Vim.maybeInitVimState_(cm);
     CodeMirror.Vim.mapclear();
+    CodeMirror.Vim.langmap('');
 
     cm.focus();
     // workaround for cm5 slow polling in blurred window
@@ -5669,6 +5670,30 @@ isOldCodeMirror || testVim('langmap_visual_block_no_ctrl_remap', function(cm, vi
   helpers.doKeys('world');
   eq('1hworld\n5hworld\nahworld', cm.getValue());
 }, {value: '1234\n5678\nabcdefg'});
+
+testVim('rendered_cursor_position_cm6', function(cm, vim, helpers) {
+  if (!cm.cm6) return;
+  cm.setCursor(0, 1);
+  helpers.doKeys('V');
+  function testCursorPosition(line, ch) {
+    cm.refresh();
+    var coords = cm.charCoords({line, ch});
+    var cursorRect = cm.getWrapperElement().querySelector(".cm-fat-cursor").getBoundingClientRect();
+    var contentRect = cm.getInputField().getBoundingClientRect();
+
+    is(Math.abs(coords.top - (cursorRect.top - contentRect.top)) < 2);
+    is(Math.abs(coords.left - (cursorRect.left - contentRect.left)) < 2);
+  }
+  testCursorPosition(0, 4);
+  helpers.doKeys('j');
+  testCursorPosition(1, 0);
+  helpers.doKeys('j');
+  testCursorPosition(2, 0);
+  helpers.doKeys('j');
+  testCursorPosition(3, 4);
+
+}, {value: '1234\n\n\n5678\nabcdefg'});
+
 
 
 async function delay(t) {


### PR DESCRIPTION
fixes https://github.com/replit/codemirror-vim/issues/171