### PR TITLE
Implement rot13 cypher

### DIFF
--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1408,7 +1408,7 @@ testVim('g?', function(cm, vim, helpers) {
   var register = helpers.getRegisterController().getRegister();
   eq('', register.toString());
   is(!register.linewise);
-
+  
   cm.setCursor(curStart);
   cm.setValue('abc efg();\nxyz');
   helpers.doKeys('g', '?', 'g', '?');
@@ -1420,9 +1420,9 @@ testVim('g?', function(cm, vim, helpers) {
   eq(cm.getValue(), 'nop rst();\nklm');
 
   cm.setCursor(curStart);
-  cm.setValue('hello\\world');
+  cm.setValue('hello\nworld');
   helpers.doKeys('l','<C-v>','l','j','g','?');
-  eq(cm.getValue(), 'hrylo\\wbedl');
+  eq(cm.getValue(), 'hrylo\nwbeld');
 }, { value: 'wa wb xx wc wd' });
 testVim('visual_block_~', function(cm, vim, helpers) {
   cm.setCursor(1, 1);

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1386,6 +1386,44 @@ testVim('gu_and_gU', function(cm, vim, helpers) {
   helpers.doKeys('g', 'U', '2', 'U');
   eq(cm.getValue(), 'ABC EFG\nXYZ');
 }, { value: 'wa wb xx wc wd' });
+testVim('g?', function(cm, vim, helpers) {
+  var curStart = makeCursor(0, 7);
+  var value = cm.getValue();
+  cm.setCursor(curStart);
+  helpers.doKeys('2', 'g', '?', 'w');
+  eq(cm.getValue(), 'wa wb xk jp wd');
+  eqCursorPos(curStart, cm.getCursor());
+  helpers.doKeys('2', 'g', '?', 'w');
+  eq(cm.getValue(), value);
+
+  helpers.doKeys('2', 'g', '?', 'B');
+  eq(cm.getValue(), 'wa jo kx wc wd');
+  eqCursorPos(makeCursor(0, 3), cm.getCursor());
+
+  cm.setCursor(makeCursor(0, 4));
+  helpers.doKeys('g', '?', 'i', 'w');
+  eq(cm.getValue(), 'wa wb kx wc wd');
+  eqCursorPos(makeCursor(0, 3), cm.getCursor());
+
+  var register = helpers.getRegisterController().getRegister();
+  eq('', register.toString());
+  is(!register.linewise);
+
+  cm.setCursor(curStart);
+  cm.setValue('abc efg();\nxyz');
+  helpers.doKeys('g', '?', 'g', '?');
+  eq(cm.getValue(), 'nop rst();\nxyz');
+  helpers.doKeys('g', '?', '?');
+  eq(cm.getValue(), 'nop rst();\nxyz');
+  eqCursorPos(makeCursor(0, 0), cm.getCursor());
+  helpers.doKeys('g', '?', '2', '?');
+  eq(cm.getValue(), 'nop rst();\nklm');
+
+  cm.setCursor(curStart);
+  cm.setValue('hello\\world');
+  helpers.doKeys('l','<C-v>','l','j','g','?');
+  eq(cm.getValue(), 'hrylo\\wbedl');
+}, { value: 'wa wb xx wc wd' });
 testVim('visual_block_~', function(cm, vim, helpers) {
   cm.setCursor(1, 1);
   helpers.doKeys('<C-v>', 'l', 'l', 'j', '~');

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -1414,7 +1414,7 @@ testVim('g?', function(cm, vim, helpers) {
   helpers.doKeys('g', '?', 'g', '?');
   eq(cm.getValue(), 'nop rst();\nxyz');
   helpers.doKeys('g', '?', '?');
-  eq(cm.getValue(), 'nop rst();\nxyz');
+  eq(cm.getValue(), 'abc efg();\nxyz');
   eqCursorPos(makeCursor(0, 0), cm.getCursor());
   helpers.doKeys('g', '?', '2', '?');
   eq(cm.getValue(), 'nop rst();\nklm');


### PR DESCRIPTION
# Why
ROT13 cypher is a weak cypher that allows you to quickly masquerade some text. It's a self-inverse function, so applying it again will decrypt the text. Original Vim implements ROT13 cypher under the `g?` keybinding.

It is particularly useful for note-taking as an example. In a studying scenario, you can write down questions with answers while applying ROT13 on the latter. To check the answers, you simply need to apply the transformation again.

# What changed
Added the `g?` operator.

# Test plan
I modified the tests for `gu` and `gU`, since they implement similar functionality. I currently test:
- A few example words
- Involution of `g?`
- `g?` on a single line
- `g?` with motions
- `g?` in visual mode