### PR TITLE
fix substitution with empty string

### DIFF
--- a/src/cm_adapter.ts
+++ b/src/cm_adapter.ts
@@ -470,6 +470,7 @@ export class CodeMirror {
     type CM5Result = { from: Pos, to: Pos, match: string[] } | null;
     var last: CM6Result = null;
     var lastCM5Result: CM5Result = null;
+    var afterEmptyMatch = false;
 
     if (pos.ch == undefined) pos.ch = Number.MAX_VALUE;
     var firstOffset = indexFromPos(cm.cm6.state.doc, pos);
@@ -507,10 +508,10 @@ export class CodeMirror {
       find: function (back?: boolean): string[] | null | undefined {
         var doc = cm.cm6.state.doc
         if (back) {
-          let endAt = last ? (last.from == last.to ? last.to - 1 : last.from) : firstOffset
+          let endAt = last ? (afterEmptyMatch ? last.to - 1 : last.from) : firstOffset
           last = prevMatchInRange(0, endAt);
         } else {
-          let startFrom = last ? (last.from == last.to ? last.to + 1 : last.to) : firstOffset
+          let startFrom = last ? (afterEmptyMatch ? last.to + 1 : last.to) : firstOffset
           last = nextMatch(startFrom)
         }
         lastCM5Result = last && {
@@ -518,6 +519,7 @@ export class CodeMirror {
           to: posFromIndex(doc, last.to),
           match: last.match,
         }
+        afterEmptyMatch = last ? last.from == last.to : false;
         return last && last.match
       },
       from: function () { return lastCM5Result?.from },

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -4452,6 +4452,10 @@ testVim('ex_substitute_javascript', function(cm, vim, helpers) {
   // into the replace part. All should be literal (this is VIM).
   helpers.doEx('s/\\(\\d+\\)/$$ $\' $` $& \\1/g')
   eq('a $$ $\' $` $& 0 b', cm.getValue());
+
+  cm.setValue('W12345678OR12345D');
+  helpers.doEx('s/\\d//g');
+  eq('WORD', cm.getValue());
 }, { value: 'a 0 b' });
 testVim('ex_substitute_empty_arguments', function(cm,vim,helpers) {
   cm.setCursor(0, 0);


### PR DESCRIPTION
fixes https://github.com/replit/codemirror-vim/issues/188