### PR TITLE
Improve moveByCharacter for rtl text

### DIFF
--- a/src/vim.js
+++ b/src/vim.js
@@ -314,6 +314,23 @@ export function initVim(CM) {
    */
   var langmap = parseLangmap('');
 
+  function isRtlLine(line) {
+    for (let i = 0; i < line.length; i++) {
+      const char = line[i];
+      const code = char.charCodeAt(0);
+
+      // Only care about letter characters, skip spaces, numbers, punctuation
+      if (/\p{L}/u.test(char)) {
+        // If it's a letter, check if it's NOT in RTL range
+        if (code < 0x0590 || code > 0x07FF) {
+          return false; // Found a non-RTL letter
+        }
+      }
+    }
+
+    return true; // No non-RTL letters found
+  }
+
   /** @arg {CodeMirror} cm */
   function enterVimMode(cm) {
     cm.setOption('disableInput', true);
@@ -2385,6 +2402,13 @@ export function initVim(CM) {
     moveByCharacters: function(_cm, head, motionArgs) {
       var cur = head;
       var repeat = motionArgs.repeat;
+
+      // if the all text is right-to-left text, flip the direction
+      var rtlText = isRtlLine(_cm.getLine(cur.line));
+      if (rtlText) {
+        repeat = -repeat;
+      }
+
       var ch = motionArgs.forward ? cur.ch + repeat : cur.ch - repeat;
       return new Pos(cur.line, ch);
     },


### PR DESCRIPTION
# Why

Users expect the arrow keys to move the cursor at the direction the arrow is pointing to. However, in right-to-left languages, since the text is written right-to-left, the cursor currently moves in the OPPOSITE direction of the arrow.

This change flips the direction of the movement if the whole line is made out of rtl language characters. While this isn't a thorough treatment for rtl support (the behavior is as before for lines of mixed rtl/ltr characters), it is a low hanging fruit that improves the experience by a lot for the standard case of writing in one language.

WDYT?

# What changed

If a line contains only rtl language characters, arrows will move at the directions they point to.

# Test plan

1. I tested with the local `npm dev` application on the following strings:
```
זה טקסט בעברית לבדיקה.
هذه هي اللغة العربية للاختبار.

זה טקסט with English.
And this is מעורבב גם כן.
ועכשיו מילה yes ומילה no.
```
2. made sure the behavior for English stayed the same.
3. ran the test suite

# Example


https://github.com/user-attachments/assets/ab0108d9-8426-487f-ad32-8db5f1000a35



---

If accepted, I can also add some automated test.