### PR TITLE
fix visual line mode statusline display

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ const vimPlugin = ViewPlugin.fromClass(
         if (!cm.state.vim) return;
         cm.state.vim.mode = e.mode;
         if (e.subMode) {
-          cm.state.vim.mode += " block";
+          cm.state.vim.mode += e.subMode === "linewise" ? " line" : " block";
         }
         cm.state.vim.status = "";
         this.blockCursor.scheduleRedraw();


### PR DESCRIPTION
# Why

When pressing `Shift+V`, it is expected to enter Visual Line mode, but the status line displays "VISUAL BLOCK" instead.

# What changed

The status line correctly displays "VISUAL LINE" when `Shift+V` is pressed.

# Test plan

1. Press `Shift+V`.  
2. The status line displays "VISUAL LINE".  
