### PR TITLE
feat: implement select mode

### DIFF
--- a/src/vim.js
+++ b/src/vim.js
@@ -216,6 +216,8 @@ export function initVim(CM) {
     { keys: 'V', type: 'action', action: 'toggleVisualMode', actionArgs: { linewise: true }},
     { keys: '<C-v>', type: 'action', action: 'toggleVisualMode', actionArgs: { blockwise: true }},
     { keys: '<C-q>', type: 'action', action: 'toggleVisualMode', actionArgs: { blockwise: true }},
+    { keys: '<C-g>', type: 'action', action: 'toggleSelectMode', context: 'visual'},
+    { keys: '<C-g>', type: 'action', action: 'toggleSelectMode', context: 'insert'},
     { keys: 'gv', type: 'action', action: 'reselectLastSelection' },
     { keys: 'J', type: 'action', action: 'joinLines', isEdit: true },
     { keys: 'gJ', type: 'action', action: 'joinLines', actionArgs: { keepSpaces: true }, isEdit: true },
@@ -3150,6 +3152,22 @@ export function initVim(CM) {
         updateCmSelection(cm);
       } else {
         exitVisualMode(cm);
+      }
+    },
+    toggleSelectMode: function(cm, actionArgs, vim) {
+      const selections = cm.listSelections();
+      const has_selection = selections.some(
+        (s) => s.anchor.line !== s.head.line || s.anchor.ch !== s.head.ch
+      );
+      if (!has_selection) {
+        return;
+      }
+      if (vim.insertMode) {
+        exitInsertMode(cm);
+        cm.setSelections(selections);
+      } else if (vim.visualMode) {
+          this.enterInsertMode(cm, {repeat: actionArgs.repeat}, vim);
+          cm.setSelections(selections);
       }
     },
     reselectLastSelection: function(cm, _actionArgs, vim) {


### PR DESCRIPTION
# Why
Implements #239

There are some usefull keybindings in insert mode while having something selected, for example surrounding the current selection with (), but selecting the right text is easier in visual mode than using a mouse or arrow keys. Vim also a select mode at https://vimhelp.org/visual.txt.html#Select, this only implements switching between visual and insert mode while keeping the selection and doesn't keep the selection mode (blockmode, linewise, normal).

Example:

https://github.com/user-attachments/assets/e3576505-6acf-4e5f-bb8a-e3d80fc8e65f




# What changed
Adds an action binded to `<C-g>` that runs in insert mode and visual mode. If there is a selection, it switches between `visual` and `insert` mode while keeping the current selections.
Ideally it doesn't overwrite the `<C-g>` keybinding when there is no selection, but couldn't find a way to do that.

<!--
 - Describe what changed to a level of detail that someone with little context with your PR could be able to review it.
 - People from the future should also be able to read this and understand what's going on.
 - Annotate changes with a self-review where necessary.
 - Post a screenshot or video when relevant
-->

# Test plan
1. given the following text and | is the cursor
```md
Some important text|
```
2. Select the text using the following
  - `v0` (select the entire line)
  - `<C-g>` (switch to select mode)
3. See the cursor change from block-cursor to insert cursor.
4. Test a insert-only command, for example `<C-x>`, cuts the entire line/the selected text.
5.  Repeat 1-3 and test `<C-g>` again and test a visual-only command, for example `d` (cuts the entire line).
  
<!-- 
 - Test plans should allow people without context to run through a list of steps and assert behavior.
 - If this is a bug fix, the test plan should include steps to reproduce the problem.
 - If this is a feature, the test plan should reflect a human-readable end-to-end test.
-->
