### PR TITLE
Fix dead key input in normal mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -320,33 +320,32 @@ const vimPlugin = ViewPlugin.fromClass(
             if (text === "\0\0") {
               return true;
             }
-            CodeMirror.signal(cm, 'inputEvent', {
-              type: "text",
-              text,
-              from, 
-              to,              
-            });
-            if (text.length == 1 && vimPlugin.useNextTextInput) {
-              if (vim.expectLiteralNext && view.composing) {
-                vimPlugin.compositionText = text;
-                return false
-              }
-              if (vimPlugin.compositionText) {
-                var toRemove = vimPlugin.compositionText;
-                vimPlugin.compositionText = '';
-                var head = view.state.selection.main.head
-                var textInDoc = view.state.sliceDoc(head - toRemove.length, head);
-                if (toRemove === textInDoc) {
-                  var pos = cm.getCursor();
-                  cm.replaceRange('', cm.posFromIndex(head - toRemove.length), pos);
+            if (vimPlugin.useNextTextInput) {
+              vimPlugin.useNextTextInput = false;
+              if (text.length == 1) {
+                if (vim.expectLiteralNext && view.composing) {
+                  vimPlugin.compositionText = text;
+                  return true;
                 }
+                if (vimPlugin.compositionText) {
+                  var toRemove = vimPlugin.compositionText;
+                  vimPlugin.compositionText = '';
+                  var head = view.state.selection.main.head
+                  var textInDoc = view.state.sliceDoc(head - toRemove.length, head);
+                  if (toRemove === textInDoc) {
+                    var pos = cm.getCursor();
+                    cm.replaceRange('', cm.posFromIndex(head - toRemove.length), pos);
+                  }
+                }
+                vimPlugin.handleKey({
+                  key: text,
+                  preventDefault: ()=>{},
+                  stopPropagation: ()=>{}
+                });
+                forceEndComposition(view);
               }
-              vimPlugin.handleKey({
-                key: text,
-                preventDefault: ()=>{},
-                stopPropagation: ()=>{}
-              });
-              forceEndComposition(view);
+              return true;
+            } else {
               return true;
             }
           }

--- a/src/vim.js
+++ b/src/vim.js
@@ -1216,6 +1216,10 @@ export function initVim(CM) {
    */
   function vimKeyFromEvent(e, vim) {
     var key = e.key;
+    // Normalize repeated dead key compositions (e.g., "^^" -> "^", "йй" -> "й")
+    if (key.length > 1 && key.split('').every(c => c === key[0])) {
+      key = key[0];
+    }
     if (ignoredKeys[key]) return;
     if (key.length > 1 && key[0] == "n") {
       key = key.replace("Numpad", "");


### PR DESCRIPTION
# Why

I noticed that pressing dead keys (like "^" on German keyboards) twice in Vim normal mode inserts unwanted text ("^^") instead of executing the intended Vim command (moving to the first non-whitespace character). There's also an existing GitHub issue (#159) reporting similar problems with Russian keyboards layouts.

# What changed

**src/index.ts**: Modified the `inputHandler` in the `vimPlugin` to prevent text insertion in Vim normal mode. Specifically, in the `if (vim && !vim.insertMode && !cm.curOp?.isVimOp)` block, changed the `else` clause from signaling a text input event (allowing insertion) to returning `true` (preventing insertion). This blocks dead key artifacts while preserving insert mode composition.
Self-Review: I couldn't test if this interferes with japanese IME (see: https://github.com/replit/codemirror-vim/pull/152#discussion_r1449304283), but I think it should be fine as this should only concern insert mode and there I tested compositions like "^+a" which result in the correct "â".

**src/vim.js**: Added normalization logic in `vimKeyFromEvent` to handle repeated dead key compositions. Added a check to reduce repeated characters (e.g., "^^" → "^", "йй" → "й") using `key.split('').every(c => c === key[0])`. This ensures malformed keys are corrected before processing
Self-review: Maybe this needs to be handled differently, as now pressing "й" twice results in moving down one instead of two as expected in #159 

No other files were modified.

# Test plan

**Reproduce the Problem (Before Fix):**
1. Open a CodeMirror editor with the Vim plugin enabled.
2. On a German keyboard, press the "^" key twice while in normal mode.
3. Expected: "^^" is inserted into the text instead of moving the cursor.
4. On a Russian keyboard, press "й" twice in normal mode.
5. Expected: "йй" is inserted instead of moving the cursor down twice.

**Test the Fix:**
1. Apply the changes and rebuild the plugin.
2. Repeat the above steps.
3. Assert: No text insertion occurs; the cursor moves as expected ("^" to first non-whitespace, "й" down two lines).
4. Test insert mode: Press "^" then "a" -> should compose "â" without issues. Test insertion of "й", test japanese input
5. Test composed commands like "5j", "ciw", etc. -> 
6. Test on multiple browsers/OS for dead key handling consistency.

This is a first draft some testing and discussion might be needed before merging.

