### PR TITLE
fix gj clipping at the end of document

### DIFF
--- a/src/vim.js
+++ b/src/vim.js
@@ -2443,21 +2443,15 @@ export function initVim(CM) {
         default:
           vim.lastHSPos = cm.charCoords(cur,'div').left;
       }
-      var repeat = motionArgs.repeat;
-      var res=cm.findPosV(cur,(motionArgs.forward ? repeat : -repeat),'line',vim.lastHSPos);
-      if (res.hitSide) {
-        if (motionArgs.forward) {
-          var lastCharCoords = cm.charCoords(res, 'div');
-          var goalCoords = { top: lastCharCoords.top + 8, left: vim.lastHSPos };
-          res = cm.coordsChar(goalCoords, 'div');
-        } else {
-          var resCoords = cm.charCoords(new Pos(cm.firstLine(), 0), 'div');
-          resCoords.left = vim.lastHSPos;
-          res = cm.coordsChar(resCoords, 'div');
-        }
+      var repeat = Math.round(motionArgs.repeat);
+      for (var i = 0; i < repeat; i++) {
+        var res=cm.findPosV(cur,(motionArgs.forward ? 1 : -1),'line',vim.lastHSPos);
+        if (res.hitSide) break;
+        cur = res;
       }
-      vim.lastHPos = res.ch;
-      return res;
+      if (cur != head)
+        vim.lastHPos = cur.ch;
+      return cur;
     },
     moveByPage: function(cm, head, motionArgs) {
       // CodeMirror only exposes functions that move the cursor page down, so

--- a/test/vim_test.js
+++ b/test/vim_test.js
@@ -452,8 +452,12 @@ testVim('gj_gk_clipping', function(cm,vim,helpers){
   cm.setCursor(0, 1);
   helpers.doKeys('g','j','g','j');
   helpers.assertCursorAt(2, 1);
+  helpers.doKeys('g','j');
+  helpers.assertCursorAt(2, 1);
   helpers.doKeys('g','k','g','k');
   helpers.assertCursorAt(0, 1);
+  helpers.doKeys('9','g','j');
+  helpers.assertCursorAt(2, 1);
 },{value: 'line 1\n\nline 2'});
 //testing a mix of j/k and gj/gk
 testVim('j_k_and_gj_gk', function(cm,vim,helpers){


### PR DESCRIPTION
fixes https://github.com/replit/codemirror-vim/issues/250

[Open web-demo @ c6ca1afdff160119c8ce2dcbd6483bb3c61a2b2c](https://raw.githack.com/replit/codemirror-vim/c6ca1afdff160119c8ce2dcbd6483bb3c61a2b2c/dev/web-demo.html)